### PR TITLE
Add DELETE profiles route

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "license": "UNLICENSED",
   "scripts": {
-    "dev": "tsnd --respawn --transpile-only src/app.ts",
+    "dev": "tsnd --respawn --transpile-only --exit-child src/app.ts",
     "start": "node dist/src/app.js",
     "prestart": "npm run build",
     "build": "rimraf dist && tsc -p tsconfig.json && npm run copy-images",

--- a/src/modules/social/profiles/profiles.controller.ts
+++ b/src/modules/social/profiles/profiles.controller.ts
@@ -134,8 +134,14 @@ export async function deleteProfileHandler(
     return reply.code(403).send("You can't delete other profiles")
   }
 
+  const profile = await getProfile(jwtName)
+
+  if (!profile) {
+    return reply.code(404).send("No profile with this name")
+  }
+
   try {
-    await deleteProfile(reqName)
+    await deleteProfile(jwtName)
     reply.send(204);
   } catch (error) {
     reply.code(500).send(error)

--- a/src/modules/social/profiles/profiles.route.ts
+++ b/src/modules/social/profiles/profiles.route.ts
@@ -6,7 +6,8 @@ import {
   getProfileHandler,
   updateProfileMediaHandler,
   followProfileHandler,
-  unfollowProfileHandler
+  unfollowProfileHandler,
+  deleteProfileHandler
 } from "./profiles.controller"
 
 async function profilesRoutes(server: FastifyInstance) {
@@ -125,6 +126,24 @@ async function profilesRoutes(server: FastifyInstance) {
       }
     },
     unfollowProfileHandler
+  )
+
+  server.delete(
+    "/:name",
+    {
+      preHandler: [server.authenticate],
+      schema: {
+        params: {
+          type: "object",
+          properties: {
+            name: { type: "string" }
+          }
+        },
+        tags: ["profiles"],
+        security: [{ bearerAuth: [] }]
+      }
+    },
+    deleteProfileHandler
   )
 }
 

--- a/src/modules/social/profiles/profiles.service.ts
+++ b/src/modules/social/profiles/profiles.service.ts
@@ -112,3 +112,9 @@ export const unfollowProfile = async (target: string, follower: string) => {
     }
   })
 }
+
+export const deleteProfile = async (name: string) => {
+  return await prisma.profile.delete({
+    where: { name }
+  })
+}

--- a/types/fastify.d.ts
+++ b/types/fastify.d.ts
@@ -12,8 +12,12 @@ declare module "fastify" {
 
 declare module "@fastify/jwt" {
   interface FastifyJWT {
-    id: number;
-    email: string;
-    name: string;
+    user: {
+      id: number;
+      name: string;
+      email: string;
+      avatar: string | null;
+      banner: string | null;
+    }
   }
 }


### PR DESCRIPTION
- Adds `DELETE /api/v1/social/profiles/:name`.
  - Will check if JWT name is the same as provided name param.
  - Cascades everything made by that profile. All comments, reactions, posts, etc..
- Adds JWT types for the user.
- Fixes auto-restart of ts-node-dev server. ([ref](https://stackoverflow.com/questions/62434261/ts-node-dev-not-restarting-when-changes-made))

[Here](https://github.com/NoroffFEU/noroff-api-docs/pull/5) is PR for updating docs.