### PR TITLE
[WIP] Add search endpoints to v2

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -7,7 +7,8 @@ const jestConfig: JestConfigWithTsJest = {
   setupFilesAfterEnv: ["<rootDir>/src/test-utils/server.ts"],
   moduleNameMapper: {
     "^@/(.*)$": "<rootDir>/src/$1"
-  }
+  },
+  workerIdleMemoryLimit: "512MB"
 }
 
 export default jestConfig

--- a/src/modules/v2/auction/listings/__tests__/searchListings.test.ts
+++ b/src/modules/v2/auction/listings/__tests__/searchListings.test.ts
@@ -57,7 +57,7 @@ describe("[GET] /v2/auction/listings/search", () => {
 
   it("should return listings with pagination and sort", async () => {
     const response = await server.inject({
-      url: `/api/v2/auction/listings/search?q=chair&sort=endsAt&sortOrder=desc&limit=1&page=1`,
+      url: `/api/v2/auction/listings/search?q=chair&sort=title&sortOrder=desc&limit=1&page=1`,
       method: "GET"
     })
     const res = await response.json()

--- a/src/modules/v2/auction/listings/__tests__/searchListings.test.ts
+++ b/src/modules/v2/auction/listings/__tests__/searchListings.test.ts
@@ -1,0 +1,112 @@
+import { server, registerUser } from "@/test-utils"
+import { db } from "@/utils"
+
+beforeEach(async () => {
+  const { name } = await registerUser()
+
+  await db.auctionListing.createMany({
+    data: [
+      {
+        title: "Blue chair",
+        description: "Selling a blue chair",
+        endsAt: new Date(new Date().setMinutes(new Date().getMinutes() + 5)),
+        sellerName: name
+      },
+      {
+        title: "Dinner table with 2 chairs",
+        description: "Selling a dinner table with 2 chairs",
+        endsAt: new Date(new Date().setMonth(new Date().getMinutes() + 5)),
+        sellerName: name
+      }
+    ]
+  })
+})
+
+afterEach(async () => {
+  const media = db.media.deleteMany()
+  const users = db.userProfile.deleteMany()
+  const listings = db.auctionListing.deleteMany()
+
+  await db.$transaction([media, users, listings])
+  await db.$disconnect()
+})
+
+describe("[GET] /v2/auction/listings/search", () => {
+  it("should return listings that contain query in either title or description", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/listings/search?q=blue`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("title", "Blue chair")
+  })
+
+  it("should return empty array if no listings match query", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/listings/search?q=random`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(0)
+  })
+
+  it("should return listings with pagination and sort", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/listings/search?q=chair&sort=endsAt&sortOrder=desc&limit=1&page=1`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("title", "Dinner table with 2 chairs")
+    expect(res.meta).toStrictEqual({
+      isFirstPage: true,
+      isLastPage: false,
+      currentPage: 1,
+      previousPage: null,
+      nextPage: 2,
+      pageCount: 2,
+      totalCount: 2
+    })
+  })
+
+  it("should throw zod error if query param is missing", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/listings/search`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Query is required",
+      path: ["q"]
+    })
+  })
+
+  it("should throw zod error if query param is empty", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/listings/search?q=`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "too_small",
+      message: "Query cannot be empty",
+      path: ["q"]
+    })
+  })
+})

--- a/src/modules/v2/auction/listings/listings.route.ts
+++ b/src/modules/v2/auction/listings/listings.route.ts
@@ -6,7 +6,8 @@ import {
   createListingHandler,
   updateListingHandler,
   deleteListingHandler,
-  createListingBidHandler
+  createListingBidHandler,
+  searchListingsHandler
 } from "./listings.controller"
 import {
   listingQuerySchema,
@@ -15,7 +16,8 @@ import {
   listingIdParamsSchema,
   createListingSchema,
   updateListingSchema,
-  bidBodySchema
+  bidBodySchema,
+  searchQuerySchema
 } from "./listings.schema"
 import { createResponseSchema } from "@/utils/createResponseSchema"
 
@@ -47,6 +49,20 @@ async function listingsRoutes(server: FastifyInstance) {
       }
     },
     getListingHandler
+  )
+
+  server.get(
+    "/search",
+    {
+      schema: {
+        tags: ["auction-listings"],
+        querystring: searchQuerySchema,
+        response: {
+          200: createResponseSchema(listingResponseSchema.array())
+        }
+      }
+    },
+    searchListingsHandler
   )
 
   server.post(

--- a/src/modules/v2/auction/listings/listings.schema.ts
+++ b/src/modules/v2/auction/listings/listings.schema.ts
@@ -147,6 +147,12 @@ export const bidBodySchema = z.object({
     .positive("Amount must be a positive number")
 })
 
+export const searchQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore).extend({
+  q: z
+    .string({ required_error: "Query is required", invalid_type_error: "Query must be a string" })
+    .nonempty("Query cannot be empty")
+})
+
 export type CreateListingSchema = z.infer<typeof createListingSchema>
 
 export type UpdateListingSchema = z.infer<typeof updateListingSchema>

--- a/src/modules/v2/auction/listings/listings.schema.ts
+++ b/src/modules/v2/auction/listings/listings.schema.ts
@@ -1,12 +1,12 @@
 import { z } from "zod"
 import { displayProfileSchema } from "../profiles/profiles.schema"
 import { sortAndPaginationSchema } from "@/utils/sortAndPaginationSchema"
-import { mediaProperties, mediaPropertiesWithErrors } from "../../auth/auth.schema"
+import { mediaProperties, mediaPropertiesWithErrors, profileCore } from "../../auth/auth.schema"
 
 const bidCore = {
   id: z.string().uuid(),
   amount: z.number(),
-  bidderName: z.string(),
+  bidder: z.object(profileCore),
   created: z.date()
 }
 

--- a/src/modules/v2/auction/listings/listings.service.ts
+++ b/src/modules/v2/auction/listings/listings.service.ts
@@ -15,6 +15,10 @@ export async function getListings(
 ) {
   const whereTag = tag ? { tags: { has: tag } } : {}
   const whereActive = active ? { endsAt: { gte: new Date() } } : {}
+  const withSellerMedia = includes.seller ? { seller: { include: { avatar: true, banner: true } } } : {}
+  const withBidderMedia = includes.bids
+    ? { bids: { include: { bidder: { include: { avatar: true, banner: true } } } } }
+    : {}
 
   const [data, meta] = await db.auctionListing
     .paginate({
@@ -24,6 +28,8 @@ export async function getListings(
       },
       include: {
         ...includes,
+        ...withSellerMedia,
+        ...withBidderMedia,
         media: true,
         _count: {
           select: {
@@ -44,11 +50,18 @@ export async function getListings(
 }
 
 export async function getListing(id: string, includes: AuctionListingIncludes = {}) {
+  const withSellerMedia = includes.seller ? { seller: { include: { avatar: true, banner: true } } } : {}
+  const withBidderMedia = includes.bids
+    ? { bids: { include: { bidder: { include: { avatar: true, banner: true } } } } }
+    : {}
+
   const [data, meta] = await db.auctionListing
     .paginate({
       where: { id },
       include: {
         ...includes,
+        ...withSellerMedia,
+        ...withBidderMedia,
         media: true,
         _count: {
           select: {
@@ -65,6 +78,11 @@ export async function getListing(id: string, includes: AuctionListingIncludes = 
 }
 
 export async function createListing(data: CreateListingSchema, seller: string, includes: AuctionListingIncludes = {}) {
+  const withSellerMedia = includes.seller ? { seller: { include: { avatar: true, banner: true } } } : {}
+  const withBidderMedia = includes.bids
+    ? { bids: { include: { bidder: { include: { avatar: true, banner: true } } } } }
+    : {}
+
   const listing = await db.auctionListing.create({
     data: {
       ...data,
@@ -74,6 +92,8 @@ export async function createListing(data: CreateListingSchema, seller: string, i
     },
     include: {
       ...includes,
+      ...withSellerMedia,
+      ...withBidderMedia,
       media: true,
       _count: {
         select: {
@@ -93,6 +113,11 @@ export async function updateListing(
   updateData: UpdateListingSchema,
   includes: AuctionListingIncludes = {}
 ) {
+  const withSellerMedia = includes.seller ? { seller: { include: { avatar: true, banner: true } } } : {}
+  const withBidderMedia = includes.bids
+    ? { bids: { include: { bidder: { include: { avatar: true, banner: true } } } } }
+    : {}
+
   const data = await db.auctionListing.update({
     where: { id },
     data: {
@@ -103,6 +128,8 @@ export async function updateListing(
     },
     include: {
       ...includes,
+      ...withSellerMedia,
+      ...withBidderMedia,
       media: true,
       _count: {
         select: {
@@ -170,6 +197,11 @@ export async function searchListings(
   query: string,
   includes: AuctionListingIncludes = {}
 ) {
+  const withSellerMedia = includes.seller ? { seller: { include: { avatar: true, banner: true } } } : {}
+  const withBidderMedia = includes.bids
+    ? { bids: { include: { bidder: { include: { avatar: true, banner: true } } } } }
+    : {}
+
   const [data, meta] = await db.auctionListing
     .paginate({
       where: {
@@ -180,6 +212,8 @@ export async function searchListings(
       },
       include: {
         ...includes,
+        ...withSellerMedia,
+        ...withBidderMedia,
         media: true,
         _count: {
           select: {

--- a/src/modules/v2/auction/profiles/__tests__/searchProfiles.test.ts
+++ b/src/modules/v2/auction/profiles/__tests__/searchProfiles.test.ts
@@ -1,0 +1,95 @@
+import { server, registerUser } from "@/test-utils"
+import { db } from "@/utils"
+
+beforeEach(async () => {
+  await registerUser()
+  await registerUser({ name: "test_user_two", email: "test_user_two@noroff.no" })
+})
+
+afterEach(async () => {
+  const media = db.media.deleteMany()
+  const users = db.userProfile.deleteMany()
+
+  await db.$transaction([media, users])
+  await db.$disconnect()
+})
+
+describe("[GET] /v2/auction/profiles/search", () => {
+  it("should return profiles that contain query in either name or bio", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search?q=two`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "test_user_two")
+  })
+
+  it("should return empty array if no profiles match query", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search?q=random`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(0)
+  })
+
+  it("should return profiles with pagination and sort", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search?q=user&sort=name&sortOrder=desc&limit=1&page=1`,
+      method: "GET"
+    })
+    const res = await response.json()
+    console.dir(res, { depth: null })
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "test_user_two")
+    expect(res.meta).toStrictEqual({
+      isFirstPage: true,
+      isLastPage: false,
+      currentPage: 1,
+      previousPage: null,
+      nextPage: 2,
+      pageCount: 2,
+      totalCount: 2
+    })
+  })
+
+  it("should throw zod error if query param is missing", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Query is required",
+      path: ["q"]
+    })
+  })
+
+  it("should throw zod error if query param is empty", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search?q=`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "too_small",
+      message: "Query cannot be empty",
+      path: ["q"]
+    })
+  })
+})

--- a/src/modules/v2/auction/profiles/__tests__/searchProfiles.test.ts
+++ b/src/modules/v2/auction/profiles/__tests__/searchProfiles.test.ts
@@ -44,7 +44,7 @@ describe("[GET] /v2/auction/profiles/search", () => {
       method: "GET"
     })
     const res = await response.json()
-    console.dir(res, { depth: null })
+
     expect(response.statusCode).toEqual(200)
     expect(res.data).toHaveLength(1)
     expect(res.data[0]).toHaveProperty("name", "test_user_two")

--- a/src/modules/v2/auction/profiles/__tests__/searchProfiles.test.ts
+++ b/src/modules/v2/auction/profiles/__tests__/searchProfiles.test.ts
@@ -1,9 +1,15 @@
-import { server, registerUser } from "@/test-utils"
+import { server, registerUser, getAuthCredentials } from "@/test-utils"
 import { db } from "@/utils"
 
+let BEARER_TOKEN = ""
+let API_KEY = ""
+
 beforeEach(async () => {
-  await registerUser()
+  const { bearerToken, apiKey } = await getAuthCredentials()
   await registerUser({ name: "test_user_two", email: "test_user_two@noroff.no" })
+
+  BEARER_TOKEN = bearerToken
+  API_KEY = apiKey
 })
 
 afterEach(async () => {
@@ -18,7 +24,11 @@ describe("[GET] /v2/auction/profiles/search", () => {
   it("should return profiles that contain query in either name or bio", async () => {
     const response = await server.inject({
       url: `/api/v2/auction/profiles/search?q=two`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -30,7 +40,11 @@ describe("[GET] /v2/auction/profiles/search", () => {
   it("should return empty array if no profiles match query", async () => {
     const response = await server.inject({
       url: `/api/v2/auction/profiles/search?q=random`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -41,7 +55,11 @@ describe("[GET] /v2/auction/profiles/search", () => {
   it("should return profiles with pagination and sort", async () => {
     const response = await server.inject({
       url: `/api/v2/auction/profiles/search?q=user&sort=name&sortOrder=desc&limit=1&page=1`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -62,7 +80,11 @@ describe("[GET] /v2/auction/profiles/search", () => {
   it("should throw zod error if query param is missing", async () => {
     const response = await server.inject({
       url: `/api/v2/auction/profiles/search`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -79,7 +101,11 @@ describe("[GET] /v2/auction/profiles/search", () => {
   it("should throw zod error if query param is empty", async () => {
     const response = await server.inject({
       url: `/api/v2/auction/profiles/search?q=`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -90,6 +116,46 @@ describe("[GET] /v2/auction/profiles/search", () => {
       code: "too_small",
       message: "Query cannot be empty",
       path: ["q"]
+    })
+  })
+
+  it("should throw 401 error when attempting to access without API key", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search?q=two`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(401)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "No API key header was found"
+    })
+  })
+
+  it("should throw 401 error when attempting to access without Bearer token", async () => {
+    const response = await server.inject({
+      url: `/api/v2/auction/profiles/search?q=two`,
+      method: "PUT",
+      headers: {
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(401)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "No authorization header was found"
     })
   })
 })

--- a/src/modules/v2/auction/profiles/profiles.route.ts
+++ b/src/modules/v2/auction/profiles/profiles.route.ts
@@ -58,6 +58,7 @@ async function profilesRoutes(server: FastifyInstance) {
   server.get(
     "/search",
     {
+      onRequest: [server.authenticate, server.apiKey],
       schema: {
         tags: ["auction-listings"],
         querystring: searchQuerySchema,

--- a/src/modules/v2/auction/profiles/profiles.route.ts
+++ b/src/modules/v2/auction/profiles/profiles.route.ts
@@ -6,7 +6,8 @@ import {
   updateProfileSchema,
   profileNameSchema,
   queryFlagsSchema,
-  profileCreditsSchema
+  profileCreditsSchema,
+  searchQuerySchema
 } from "./profiles.schema"
 import {
   getProfilesHandler,
@@ -14,7 +15,8 @@ import {
   updateProfileHandler,
   getProfileListingsHandler,
   getProfileCreditsHandler,
-  getProfileBidsHandler
+  getProfileBidsHandler,
+  searchProfilesHandler
 } from "./profiles.controller"
 import { createResponseSchema } from "@/utils/createResponseSchema"
 import { listingQuerySchema, listingResponseSchema, profileBidsResponseSchema } from "../listings/listings.schema"
@@ -51,6 +53,20 @@ async function profilesRoutes(server: FastifyInstance) {
       }
     },
     getProfileHandler
+  )
+
+  server.get(
+    "/search",
+    {
+      schema: {
+        tags: ["auction-listings"],
+        querystring: searchQuerySchema,
+        response: {
+          200: createResponseSchema(displayProfileSchema.array())
+        }
+      }
+    },
+    searchProfilesHandler
   )
 
   server.put(

--- a/src/modules/v2/auction/profiles/profiles.schema.ts
+++ b/src/modules/v2/auction/profiles/profiles.schema.ts
@@ -69,6 +69,12 @@ const queryFlagsCore = {
   _listings: z.preprocess(val => String(val).toLowerCase() === "true", z.boolean()).optional()
 }
 
+export const searchQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore).extend({
+  q: z
+    .string({ required_error: "Query is required", invalid_type_error: "Query must be a string" })
+    .nonempty("Query cannot be empty")
+})
+
 export const queryFlagsSchema = z.object(queryFlagsCore)
 
 export const profilesQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore)

--- a/src/modules/v2/auction/profiles/profiles.service.ts
+++ b/src/modules/v2/auction/profiles/profiles.service.ts
@@ -147,7 +147,13 @@ export async function getProfileBids(
         [sort]: sortOrder
       },
       include: {
-        ...includes
+        ...includes,
+        bidder: {
+          include: {
+            avatar: true,
+            banner: true
+          }
+        }
       }
     })
     .withPages({

--- a/src/modules/v2/auction/profiles/profiles.service.ts
+++ b/src/modules/v2/auction/profiles/profiles.service.ts
@@ -177,7 +177,7 @@ export async function searchProfiles(
         banner: true,
         _count: {
           select: {
-            bids: true
+            listings: true
           }
         }
       },

--- a/src/modules/v2/auction/profiles/profiles.service.ts
+++ b/src/modules/v2/auction/profiles/profiles.service.ts
@@ -157,3 +157,38 @@ export async function getProfileBids(
 
   return { data, meta }
 }
+
+export async function searchProfiles(
+  sort: keyof UserProfile = "name",
+  sortOrder: "asc" | "desc" = "desc",
+  limit = 100,
+  page = 1,
+  query: string,
+  includes: AuctionProfileIncludes = {}
+) {
+  const [data, meta] = await db.userProfile
+    .paginate({
+      where: {
+        OR: [{ name: { contains: query, mode: "insensitive" } }, { bio: { contains: query, mode: "insensitive" } }]
+      },
+      include: {
+        ...includes,
+        avatar: true,
+        banner: true,
+        _count: {
+          select: {
+            bids: true
+          }
+        }
+      },
+      orderBy: {
+        [sort]: sortOrder
+      }
+    })
+    .withPages({
+      limit,
+      page
+    })
+
+  return { data, meta }
+}

--- a/src/modules/v2/holidaze/profiles/__tests__/searchProfiles.test.ts
+++ b/src/modules/v2/holidaze/profiles/__tests__/searchProfiles.test.ts
@@ -1,0 +1,95 @@
+import { server, registerUser } from "@/test-utils"
+import { db } from "@/utils"
+
+beforeEach(async () => {
+  await registerUser()
+  await registerUser({ name: "test_user_two", email: "test_user_two@noroff.no" })
+})
+
+afterEach(async () => {
+  const media = db.media.deleteMany()
+  const users = db.userProfile.deleteMany()
+
+  await db.$transaction([media, users])
+  await db.$disconnect()
+})
+
+describe("[GET] /v2/holidaze/profiles/search", () => {
+  it("should return profiles that contain query in either name or bio", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search?q=two`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "test_user_two")
+  })
+
+  it("should return empty array if no profiles match query", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search?q=random`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(0)
+  })
+
+  it("should return profiles with pagination and sort", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search?q=user&sort=name&sortOrder=desc&limit=1&page=1`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "test_user_two")
+    expect(res.meta).toStrictEqual({
+      isFirstPage: true,
+      isLastPage: false,
+      currentPage: 1,
+      previousPage: null,
+      nextPage: 2,
+      pageCount: 2,
+      totalCount: 2
+    })
+  })
+
+  it("should throw zod error if query param is missing", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Query is required",
+      path: ["q"]
+    })
+  })
+
+  it("should throw zod error if query param is empty", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search?q=`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "too_small",
+      message: "Query cannot be empty",
+      path: ["q"]
+    })
+  })
+})

--- a/src/modules/v2/holidaze/profiles/__tests__/searchProfiles.test.ts
+++ b/src/modules/v2/holidaze/profiles/__tests__/searchProfiles.test.ts
@@ -1,9 +1,15 @@
-import { server, registerUser } from "@/test-utils"
+import { server, registerUser, getAuthCredentials } from "@/test-utils"
 import { db } from "@/utils"
 
+let BEARER_TOKEN = ""
+let API_KEY = ""
+
 beforeEach(async () => {
-  await registerUser()
+  const { bearerToken, apiKey } = await getAuthCredentials()
   await registerUser({ name: "test_user_two", email: "test_user_two@noroff.no" })
+
+  BEARER_TOKEN = bearerToken
+  API_KEY = apiKey
 })
 
 afterEach(async () => {
@@ -18,7 +24,11 @@ describe("[GET] /v2/holidaze/profiles/search", () => {
   it("should return profiles that contain query in either name or bio", async () => {
     const response = await server.inject({
       url: `/api/v2/holidaze/profiles/search?q=two`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -30,7 +40,11 @@ describe("[GET] /v2/holidaze/profiles/search", () => {
   it("should return empty array if no profiles match query", async () => {
     const response = await server.inject({
       url: `/api/v2/holidaze/profiles/search?q=random`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -41,7 +55,11 @@ describe("[GET] /v2/holidaze/profiles/search", () => {
   it("should return profiles with pagination and sort", async () => {
     const response = await server.inject({
       url: `/api/v2/holidaze/profiles/search?q=user&sort=name&sortOrder=desc&limit=1&page=1`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -62,7 +80,11 @@ describe("[GET] /v2/holidaze/profiles/search", () => {
   it("should throw zod error if query param is missing", async () => {
     const response = await server.inject({
       url: `/api/v2/holidaze/profiles/search`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -79,7 +101,11 @@ describe("[GET] /v2/holidaze/profiles/search", () => {
   it("should throw zod error if query param is empty", async () => {
     const response = await server.inject({
       url: `/api/v2/holidaze/profiles/search?q=`,
-      method: "GET"
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
     })
     const res = await response.json()
 
@@ -90,6 +116,46 @@ describe("[GET] /v2/holidaze/profiles/search", () => {
       code: "too_small",
       message: "Query cannot be empty",
       path: ["q"]
+    })
+  })
+
+  it("should throw 401 error when attempting to access without API key", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search?q=two`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(401)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "No API key header was found"
+    })
+  })
+
+  it("should throw 401 error when attempting to access without Bearer token", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/profiles/search?q=two`,
+      method: "PUT",
+      headers: {
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(401)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "No authorization header was found"
     })
   })
 })

--- a/src/modules/v2/holidaze/profiles/profiles.route.ts
+++ b/src/modules/v2/holidaze/profiles/profiles.route.ts
@@ -5,14 +5,16 @@ import {
   profilesQuerySchema,
   profileNameSchema,
   queryFlagsSchema,
-  updateProfileSchema
+  updateProfileSchema,
+  searchQuerySchema
 } from "./profiles.schema"
 import {
   getProfilesHandler,
   getProfileHandler,
   updateProfileHandler,
   getProfileVenuesHandler,
-  getProfileBookingsHandler
+  getProfileBookingsHandler,
+  searchProfilesHandler
 } from "./profiles.controller"
 import { createResponseSchema } from "@/utils/createResponseSchema"
 
@@ -51,6 +53,20 @@ async function profilesRoutes(server: FastifyInstance) {
       }
     },
     getProfileHandler
+  )
+
+  server.get(
+    "/search",
+    {
+      schema: {
+        tags: ["auction-listings"],
+        querystring: searchQuerySchema,
+        response: {
+          200: createResponseSchema(displayProfileSchema.array())
+        }
+      }
+    },
+    searchProfilesHandler
   )
 
   server.put(

--- a/src/modules/v2/holidaze/profiles/profiles.route.ts
+++ b/src/modules/v2/holidaze/profiles/profiles.route.ts
@@ -59,7 +59,7 @@ async function profilesRoutes(server: FastifyInstance) {
     "/search",
     {
       schema: {
-        tags: ["auction-listings"],
+        tags: ["holidaze-profiles"],
         querystring: searchQuerySchema,
         response: {
           200: createResponseSchema(displayProfileSchema.array())

--- a/src/modules/v2/holidaze/profiles/profiles.route.ts
+++ b/src/modules/v2/holidaze/profiles/profiles.route.ts
@@ -58,6 +58,7 @@ async function profilesRoutes(server: FastifyInstance) {
   server.get(
     "/search",
     {
+      onRequest: [server.authenticate, server.apiKey],
       schema: {
         tags: ["holidaze-profiles"],
         querystring: searchQuerySchema,

--- a/src/modules/v2/holidaze/profiles/profiles.schema.ts
+++ b/src/modules/v2/holidaze/profiles/profiles.schema.ts
@@ -64,6 +64,12 @@ const queryFlagsCore = {
   _venues: z.preprocess(val => String(val).toLowerCase() === "true", z.boolean()).optional()
 }
 
+export const searchQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore).extend({
+  q: z
+    .string({ required_error: "Query is required", invalid_type_error: "Query must be a string" })
+    .nonempty("Query cannot be empty")
+})
+
 export const queryFlagsSchema = z.object(queryFlagsCore)
 
 export const profilesQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore)

--- a/src/modules/v2/holidaze/profiles/profiles.service.ts
+++ b/src/modules/v2/holidaze/profiles/profiles.service.ts
@@ -146,3 +146,38 @@ export async function getProfileBookings(
 
   return { data, meta }
 }
+
+export async function searchProfiles(
+  sort: keyof UserProfile = "name",
+  sortOrder: "asc" | "desc" = "desc",
+  limit = 100,
+  page = 1,
+  query: string,
+  includes: HolidazeProfileIncludes = {}
+) {
+  const [data, meta] = await db.userProfile
+    .paginate({
+      where: {
+        OR: [{ name: { contains: query, mode: "insensitive" } }, { bio: { contains: query, mode: "insensitive" } }]
+      },
+      include: {
+        ...includes,
+        avatar: true,
+        banner: true,
+        _count: {
+          select: {
+            bids: true
+          }
+        }
+      },
+      orderBy: {
+        [sort]: sortOrder
+      }
+    })
+    .withPages({
+      limit,
+      page
+    })
+
+  return { data, meta }
+}

--- a/src/modules/v2/holidaze/profiles/profiles.service.ts
+++ b/src/modules/v2/holidaze/profiles/profiles.service.ts
@@ -13,6 +13,9 @@ export async function getProfiles(
   includes: HolidazeProfileIncludes = {}
 ) {
   const venueMetaAndLocation = includes.venues ? { venues: { include: { meta: true, location: true } } } : {}
+  const includeVenueIfBookings = includes.bookings
+    ? { bookings: { include: { venue: { include: { meta: true, location: true } } } } }
+    : {}
 
   const [data, meta] = await db.userProfile
     .paginate({
@@ -22,6 +25,7 @@ export async function getProfiles(
       include: {
         ...includes,
         ...venueMetaAndLocation,
+        ...includeVenueIfBookings,
         _count: {
           select: {
             venues: true,
@@ -89,6 +93,9 @@ export async function getProfileVenues(
   includes: HolidazeVenueIncludes = {}
 ) {
   const withProfileMedia = includes.owner ? { owner: { include: { avatar: true, banner: true } } } : {}
+  const withBookings = includes.bookings
+    ? { bookings: { include: { customer: { include: { avatar: true, banner: true } } } } }
+    : {}
 
   const [data, meta] = await db.holidazeVenue
     .paginate({
@@ -99,6 +106,7 @@ export async function getProfileVenues(
       include: {
         ...includes,
         ...withProfileMedia,
+        ...withBookings,
         meta: true,
         location: true,
         _count: {
@@ -155,6 +163,11 @@ export async function searchProfiles(
   query: string,
   includes: HolidazeProfileIncludes = {}
 ) {
+  const venueMetaAndLocation = includes.venues ? { venues: { include: { meta: true, location: true } } } : {}
+  const includeVenueIfBookings = includes.bookings
+    ? { bookings: { include: { venue: { include: { meta: true, location: true } } } } }
+    : {}
+
   const [data, meta] = await db.userProfile
     .paginate({
       where: {
@@ -162,11 +175,14 @@ export async function searchProfiles(
       },
       include: {
         ...includes,
+        ...venueMetaAndLocation,
+        ...includeVenueIfBookings,
         avatar: true,
         banner: true,
         _count: {
           select: {
-            bids: true
+            venues: true,
+            bookings: true
           }
         }
       },

--- a/src/modules/v2/holidaze/venues/__tests__/searchVenues.test.ts
+++ b/src/modules/v2/holidaze/venues/__tests__/searchVenues.test.ts
@@ -1,0 +1,118 @@
+import { server, registerUser } from "@/test-utils"
+import { db } from "@/utils"
+
+beforeEach(async () => {
+  const { name } = await registerUser()
+
+  await db.holidazeVenue.create({
+    data: {
+      name: "Nice hotel",
+      description: "A nice hotel",
+      price: 100,
+      maxGuests: 2,
+      meta: { create: {} },
+      location: { create: {} },
+      owner: { connect: { name } }
+    }
+  })
+  await db.holidazeVenue.create({
+    data: {
+      name: "Nice place to stay",
+      description: "Our venue",
+      price: 100,
+      maxGuests: 2,
+      meta: { create: {} },
+      location: { create: {} },
+      owner: { connect: { name } }
+    }
+  })
+})
+
+afterEach(async () => {
+  const media = db.media.deleteMany()
+  const users = db.userProfile.deleteMany()
+  const venues = db.holidazeVenue.deleteMany()
+
+  await db.$transaction([media, users, venues])
+  await db.$disconnect()
+})
+
+describe("[GET] /v2/holidaze/venues/search", () => {
+  it("should return venues that contain query in either name or description", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/venues/search?q=venue`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "Nice place to stay")
+  })
+
+  it("should return empty array if no venues match query", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/venues/search?q=random`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(0)
+  })
+
+  it("should return venues with pagination and sort", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/venues/search?q=nice&sort=name&sortOrder=asc&limit=1&page=1`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "Nice hotel")
+    expect(res.meta).toStrictEqual({
+      isFirstPage: true,
+      isLastPage: false,
+      currentPage: 1,
+      previousPage: null,
+      nextPage: 2,
+      pageCount: 2,
+      totalCount: 2
+    })
+  })
+
+  it("should throw zod error if query param is missing", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/venues/search`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Query is required",
+      path: ["q"]
+    })
+  })
+
+  it("should throw zod error if query param is empty", async () => {
+    const response = await server.inject({
+      url: `/api/v2/holidaze/venues/search?q=`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "too_small",
+      message: "Query cannot be empty",
+      path: ["q"]
+    })
+  })
+})

--- a/src/modules/v2/holidaze/venues/venues.controller.ts
+++ b/src/modules/v2/holidaze/venues/venues.controller.ts
@@ -253,7 +253,7 @@ export async function deleteVenueHandler(
   }
 }
 
-export async function searchListingsHandler(
+export async function searchVenuesHandler(
   request: FastifyRequest<{
     Querystring: {
       limit?: number

--- a/src/modules/v2/holidaze/venues/venues.route.ts
+++ b/src/modules/v2/holidaze/venues/venues.route.ts
@@ -15,7 +15,7 @@ import {
   createVenueHandler,
   deleteVenueHandler,
   updateVenueHandler,
-  searchListingsHandler
+  searchVenuesHandler
 } from "./venues.controller"
 import { createResponseSchema } from "@/utils/createResponseSchema"
 
@@ -53,14 +53,14 @@ async function venuesRoutes(server: FastifyInstance) {
     "/search",
     {
       schema: {
-        tags: ["auction-listings"],
+        tags: ["holidaze-venues"],
         querystring: searchQuerySchema,
         response: {
           200: createResponseSchema(displayVenueSchema.array())
         }
       }
     },
-    searchListingsHandler
+    searchVenuesHandler
   )
 
   server.post(

--- a/src/modules/v2/holidaze/venues/venues.route.ts
+++ b/src/modules/v2/holidaze/venues/venues.route.ts
@@ -6,14 +6,16 @@ import {
   venueIdSchema,
   queryFlagsSchema,
   createVenueSchema,
-  updateVenueSchema
+  updateVenueSchema,
+  searchQuerySchema
 } from "./venues.schema"
 import {
   getVenuesHandler,
   getVenueHandler,
   createVenueHandler,
   deleteVenueHandler,
-  updateVenueHandler
+  updateVenueHandler,
+  searchListingsHandler
 } from "./venues.controller"
 import { createResponseSchema } from "@/utils/createResponseSchema"
 
@@ -45,6 +47,20 @@ async function venuesRoutes(server: FastifyInstance) {
       }
     },
     getVenueHandler
+  )
+
+  server.get(
+    "/search",
+    {
+      schema: {
+        tags: ["auction-listings"],
+        querystring: searchQuerySchema,
+        response: {
+          200: createResponseSchema(displayVenueSchema.array())
+        }
+      }
+    },
+    searchListingsHandler
   )
 
   server.post(

--- a/src/modules/v2/holidaze/venues/venues.schema.ts
+++ b/src/modules/v2/holidaze/venues/venues.schema.ts
@@ -66,7 +66,12 @@ export const venueCore = {
       customer: z.object(profileCore)
     })
     .array()
-    .optional()
+    .optional(),
+  _count: z
+    .object({
+      bookings: z.number().int().optional()
+    })
+    .nullish()
 }
 
 export const displayVenueSchema = z.object(venueCore)

--- a/src/modules/v2/holidaze/venues/venues.schema.ts
+++ b/src/modules/v2/holidaze/venues/venues.schema.ts
@@ -156,6 +156,12 @@ export const updateVenueSchema = z
   .object(updateVenueCore)
   .refine(data => Object.keys(data).length > 0, "You must provide at least one field to update")
 
+export const searchQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore).extend({
+  q: z
+    .string({ required_error: "Query is required", invalid_type_error: "Query must be a string" })
+    .nonempty("Query cannot be empty")
+})
+
 export type CreateVenueSchema = z.infer<typeof createVenueSchema>
 
 export type UpdateVenueSchema = z.infer<typeof updateVenueSchema>

--- a/src/modules/v2/holidaze/venues/venues.service.ts
+++ b/src/modules/v2/holidaze/venues/venues.service.ts
@@ -33,7 +33,12 @@ export async function getVenues(
         ...withBookingCustomer,
         meta: true,
         location: true,
-        media: true
+        media: true,
+        _count: {
+          select: {
+            bookings: true
+          }
+        }
       }
     })
     .withPages({
@@ -59,7 +64,12 @@ export async function getVenue(id: string, includes: HolidazeVenueIncludes = {})
         ...withBookingCustomer,
         meta: true,
         location: true,
-        media: true
+        media: true,
+        _count: {
+          select: {
+            bookings: true
+          }
+        }
       }
     })
     .withPages({
@@ -138,7 +148,12 @@ export async function updateVenue(id: string, updateData: UpdateVenueSchema, inc
       ...withOwnerMedia,
       ...withBookingCustomer,
       meta: true,
-      location: true
+      location: true,
+      _count: {
+        select: {
+          bookings: true
+        }
+      }
     }
   })
 
@@ -178,7 +193,12 @@ export async function searchVenues(
         ...withBookingCustomer,
         meta: true,
         location: true,
-        media: true
+        media: true,
+        _count: {
+          select: {
+            bookings: true
+          }
+        }
       },
       orderBy: {
         [sort]: sortOrder

--- a/src/modules/v2/social/posts/__tests__/searchPosts.test.ts
+++ b/src/modules/v2/social/posts/__tests__/searchPosts.test.ts
@@ -1,0 +1,137 @@
+import { server, getAuthCredentials } from "@/test-utils"
+import { db } from "@/utils"
+
+let BEARER_TOKEN = ""
+let API_KEY = ""
+
+beforeEach(async () => {
+  const { name, bearerToken, apiKey } = await getAuthCredentials()
+
+  BEARER_TOKEN = bearerToken
+  API_KEY = apiKey
+
+  await db.socialPost.createMany({
+    data: [
+      {
+        title: "My post",
+        body: "My awesome post",
+        tags: ["tag1"],
+        owner: name
+      },
+      {
+        title: "Another post",
+        tags: ["another_tag"],
+        owner: name
+      }
+    ]
+  })
+})
+
+afterEach(async () => {
+  const media = db.media.deleteMany()
+  const users = db.userProfile.deleteMany()
+  const venues = db.holidazeVenue.deleteMany()
+
+  await db.$transaction([media, users, venues])
+  await db.$disconnect()
+})
+
+describe("[GET] /v2/social/posts/search", () => {
+  it("should return posts that contain query in either title or body", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/posts/search?q=awesome`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("title", "My post")
+  })
+
+  it("should return empty array if no posts match query", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/posts/search?q=random`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(0)
+  })
+
+  it("should return posts with pagination and sort", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/posts/search?q=post&sort=title&sortOrder=asc&limit=1&page=1`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("title", "Another post")
+    expect(res.meta).toStrictEqual({
+      isFirstPage: true,
+      isLastPage: false,
+      currentPage: 1,
+      previousPage: null,
+      nextPage: 2,
+      pageCount: 2,
+      totalCount: 2
+    })
+  })
+
+  it("should throw zod error if query param is missing", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/posts/search`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Query is required",
+      path: ["q"]
+    })
+  })
+
+  it("should throw zod error if query param is empty", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/posts/search?q=`,
+      method: "GET",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "too_small",
+      message: "Query cannot be empty",
+      path: ["q"]
+    })
+  })
+})

--- a/src/modules/v2/social/posts/posts.route.ts
+++ b/src/modules/v2/social/posts/posts.route.ts
@@ -12,7 +12,8 @@ import {
   reactionParamsSchema,
   createCommentSchema,
   displayCommentSchema,
-  authorQuerySchema
+  authorQuerySchema,
+  searchQuerySchema
 } from "./posts.schema"
 import {
   getPostsHandler,
@@ -22,7 +23,8 @@ import {
   createOrDeleteReactionHandler,
   deletePostHandler,
   createCommentHandler,
-  getPostsOfFollowedUsersHandler
+  getPostsOfFollowedUsersHandler,
+  searchPostsHandler
 } from "./posts.controller"
 
 async function postsRoutes(server: FastifyInstance) {
@@ -56,6 +58,21 @@ async function postsRoutes(server: FastifyInstance) {
       }
     },
     getPostsOfFollowedUsersHandler
+  )
+
+  server.get(
+    "/search",
+    {
+      onRequest: [server.authenticate, server.apiKey],
+      schema: {
+        tags: ["social-posts"],
+        querystring: searchQuerySchema,
+        response: {
+          200: createResponseSchema(displayPostSchema.array())
+        }
+      }
+    },
+    searchPostsHandler
   )
 
   server.post(

--- a/src/modules/v2/social/posts/posts.schema.ts
+++ b/src/modules/v2/social/posts/posts.schema.ts
@@ -192,6 +192,12 @@ export const postsQuerySchema = sortAndPaginationSchema
   })
   .extend(queryFlagsCore)
 
+export const searchQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore).extend({
+  q: z
+    .string({ required_error: "Query is required", invalid_type_error: "Query must be a string" })
+    .nonempty("Query cannot be empty")
+})
+
 export const emojiSchema = z.string().emoji("Must be a valid emoji")
 
 export type CreatePostSchema = z.infer<typeof createPostSchema>

--- a/src/modules/v2/social/posts/posts.service.ts
+++ b/src/modules/v2/social/posts/posts.service.ts
@@ -15,6 +15,7 @@ export async function getPosts(
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
   const whereTag = tag ? { tags: { has: tag } } : {}
+  const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
 
   const [data, meta] = await db.socialPost
     .paginate({
@@ -25,6 +26,7 @@ export async function getPosts(
       include: {
         ...includes,
         ...withCommentAuthor,
+        ...withAuthorMedia,
         media: true,
         _count: {
           select: {
@@ -67,6 +69,7 @@ export async function getPost(id: number, includes: SocialPostIncludes = {}) {
   const withCommentAuthor = includes.comments
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
+  const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
 
   const [data, meta] = await db.socialPost
     .paginate({
@@ -74,6 +77,7 @@ export async function getPost(id: number, includes: SocialPostIncludes = {}) {
       include: {
         ...includes,
         ...withCommentAuthor,
+        ...withAuthorMedia,
         media: true,
         _count: {
           select: {
@@ -117,6 +121,7 @@ export const createPost = async (createPostData: CreatePostSchema, includes: Soc
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
   const withMedia = media?.url ? { media: true } : {}
+  const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
 
   const data = await db.socialPost.create({
     data: {
@@ -127,6 +132,7 @@ export const createPost = async (createPostData: CreatePostSchema, includes: Soc
       ...includes,
       ...withCommentAuthor,
       ...withMedia,
+      ...withAuthorMedia,
       _count: {
         select: {
           comments: true,
@@ -310,7 +316,7 @@ export const getPostsOfFollowedUsers = async (
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
   const whereTag = tag ? { tags: { has: tag } } : {}
-  const withProfileMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
+  const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
 
   const [data, meta] = await db.socialPost
     .paginate({
@@ -328,7 +334,7 @@ export const getPostsOfFollowedUsers = async (
       include: {
         ...includes,
         ...withCommentAuthor,
-        ...withProfileMedia,
+        ...withAuthorMedia,
         media: true,
         _count: {
           select: {
@@ -357,6 +363,7 @@ export const searchPosts = async (
   const withCommentAuthor = includes.comments
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
+  const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
 
   const [data, meta] = await db.socialPost
     .paginate({
@@ -366,6 +373,7 @@ export const searchPosts = async (
       include: {
         ...includes,
         ...withCommentAuthor,
+        ...withAuthorMedia,
         media: true,
         _count: {
           select: {

--- a/src/modules/v2/social/profiles/__tests__/searchProfiles.test.ts
+++ b/src/modules/v2/social/profiles/__tests__/searchProfiles.test.ts
@@ -1,0 +1,95 @@
+import { server, registerUser } from "@/test-utils"
+import { db } from "@/utils"
+
+beforeEach(async () => {
+  await registerUser()
+  await registerUser({ name: "test_user_two", email: "test_user_two@noroff.no" })
+})
+
+afterEach(async () => {
+  const media = db.media.deleteMany()
+  const users = db.userProfile.deleteMany()
+
+  await db.$transaction([media, users])
+  await db.$disconnect()
+})
+
+describe("[GET] /v2/social/profiles/search", () => {
+  it("should return profiles that contain query in either name or bio", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/profiles/search?q=two`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "test_user_two")
+  })
+
+  it("should return empty array if no profiles match query", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/profiles/search?q=random`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(0)
+  })
+
+  it("should return profiles with pagination and sort", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/profiles/search?q=user&sort=name&sortOrder=desc&limit=1&page=1`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(200)
+    expect(res.data).toHaveLength(1)
+    expect(res.data[0]).toHaveProperty("name", "test_user_two")
+    expect(res.meta).toStrictEqual({
+      isFirstPage: true,
+      isLastPage: false,
+      currentPage: 1,
+      previousPage: null,
+      nextPage: 2,
+      pageCount: 2,
+      totalCount: 2
+    })
+  })
+
+  it("should throw zod error if query param is missing", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/profiles/search`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Query is required",
+      path: ["q"]
+    })
+  })
+
+  it("should throw zod error if query param is empty", async () => {
+    const response = await server.inject({
+      url: `/api/v2/social/profiles/search?q=`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors[0]).toStrictEqual({
+      code: "too_small",
+      message: "Query cannot be empty",
+      path: ["q"]
+    })
+  })
+})

--- a/src/modules/v2/social/profiles/profiles.route.ts
+++ b/src/modules/v2/social/profiles/profiles.route.ts
@@ -58,6 +58,7 @@ async function profilesRoutes(server: FastifyInstance) {
   server.get(
     "/search",
     {
+      onRequest: [server.authenticate, server.apiKey],
       schema: {
         tags: ["social-profiles"],
         querystring: searchQuerySchema,

--- a/src/modules/v2/social/profiles/profiles.route.ts
+++ b/src/modules/v2/social/profiles/profiles.route.ts
@@ -6,7 +6,8 @@ import {
   updateProfileSchema,
   profileNameSchema,
   queryFlagsSchema,
-  followUnfollowProfileSchema
+  followUnfollowProfileSchema,
+  searchQuerySchema
 } from "./profiles.schema"
 import {
   getProfilesHandler,
@@ -14,7 +15,8 @@ import {
   updateProfileHandler,
   followProfileHandler,
   unfollowProfileHandler,
-  getProfilePostsHandler
+  getProfilePostsHandler,
+  searchProfilesHandler
 } from "./profiles.controller"
 import { createResponseSchema } from "@/utils/createResponseSchema"
 import { displayPostSchema, postsQuerySchema } from "../posts/posts.schema"
@@ -51,6 +53,20 @@ async function profilesRoutes(server: FastifyInstance) {
       }
     },
     getProfileHandler
+  )
+
+  server.get(
+    "/search",
+    {
+      schema: {
+        tags: ["auction-listings"],
+        querystring: searchQuerySchema,
+        response: {
+          200: createResponseSchema(displayProfileSchema.array())
+        }
+      }
+    },
+    searchProfilesHandler
   )
 
   server.put(

--- a/src/modules/v2/social/profiles/profiles.route.ts
+++ b/src/modules/v2/social/profiles/profiles.route.ts
@@ -59,7 +59,7 @@ async function profilesRoutes(server: FastifyInstance) {
     "/search",
     {
       schema: {
-        tags: ["auction-listings"],
+        tags: ["social-profiles"],
         querystring: searchQuerySchema,
         response: {
           200: createResponseSchema(displayProfileSchema.array())

--- a/src/modules/v2/social/profiles/profiles.schema.ts
+++ b/src/modules/v2/social/profiles/profiles.schema.ts
@@ -49,4 +49,10 @@ export const profilesQuerySchema = sortAndPaginationSchema
   })
   .extend(queryFlagsCore)
 
+export const searchQuerySchema = sortAndPaginationSchema.extend(queryFlagsCore).extend({
+  q: z
+    .string({ required_error: "Query is required", invalid_type_error: "Query must be a string" })
+    .nonempty("Query cannot be empty")
+})
+
 export type UpdateProfileSchema = z.infer<typeof updateProfileSchema>

--- a/src/modules/v2/social/profiles/profiles.service.ts
+++ b/src/modules/v2/social/profiles/profiles.service.ts
@@ -11,6 +11,10 @@ export async function getProfiles(
   page = 1,
   includes: ProfileIncludes = {}
 ) {
+  const withFollowersMedia = includes.followers ? { followers: { include: { avatar: true, banner: true } } } : {}
+  const withFollowingMedia = includes.following ? { following: { include: { avatar: true, banner: true } } } : {}
+  const withPostMedia = includes.posts ? { posts: { include: { media: true } } } : {}
+
   const [data, meta] = await db.userProfile
     .paginate({
       orderBy: {
@@ -18,6 +22,9 @@ export async function getProfiles(
       },
       include: {
         ...includes,
+        ...withFollowersMedia,
+        ...withFollowingMedia,
+        ...withPostMedia,
         avatar: true,
         banner: true,
         _count: {
@@ -38,11 +45,18 @@ export async function getProfiles(
 }
 
 export const getProfile = async (name: string, includes: ProfileIncludes = {}) => {
+  const withFollowersMedia = includes.followers ? { followers: { include: { avatar: true, banner: true } } } : {}
+  const withFollowingMedia = includes.following ? { following: { include: { avatar: true, banner: true } } } : {}
+  const withPostMedia = includes.posts ? { posts: { include: { media: true } } } : {}
+
   const [data, meta] = await db.userProfile
     .paginate({
       where: { name },
       include: {
         ...includes,
+        ...withFollowersMedia,
+        ...withFollowingMedia,
+        ...withPostMedia,
         avatar: true,
         banner: true,
         _count: {
@@ -146,6 +160,7 @@ export const getProfilePosts = async (
   tag: string | undefined
 ) => {
   const whereTag = tag ? { tags: { has: tag } } : {}
+  const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
   const withCommentAuthor = includes.comments
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
@@ -162,6 +177,7 @@ export const getProfilePosts = async (
       include: {
         ...includes,
         ...withCommentAuthor,
+        ...withAuthorMedia,
         _count: {
           select: {
             comments: true,
@@ -186,6 +202,10 @@ export async function searchProfiles(
   query: string,
   includes: ProfileIncludes = {}
 ) {
+  const withFollowersMedia = includes.followers ? { followers: { include: { avatar: true, banner: true } } } : {}
+  const withFollowingMedia = includes.following ? { following: { include: { avatar: true, banner: true } } } : {}
+  const withPostMedia = includes.posts ? { posts: { include: { media: true } } } : {}
+
   const [data, meta] = await db.userProfile
     .paginate({
       where: {
@@ -193,11 +213,16 @@ export async function searchProfiles(
       },
       include: {
         ...includes,
+        ...withFollowersMedia,
+        ...withFollowingMedia,
+        ...withPostMedia,
         avatar: true,
         banner: true,
         _count: {
           select: {
-            bids: true
+            posts: true,
+            followers: true,
+            following: true
           }
         }
       },

--- a/src/modules/v2/social/profiles/profiles.service.ts
+++ b/src/modules/v2/social/profiles/profiles.service.ts
@@ -177,3 +177,38 @@ export const getProfilePosts = async (
 
   return { data, meta }
 }
+
+export async function searchProfiles(
+  sort: keyof UserProfile = "name",
+  sortOrder: "asc" | "desc" = "desc",
+  limit = 100,
+  page = 1,
+  query: string,
+  includes: ProfileIncludes = {}
+) {
+  const [data, meta] = await db.userProfile
+    .paginate({
+      where: {
+        OR: [{ name: { contains: query, mode: "insensitive" } }, { bio: { contains: query, mode: "insensitive" } }]
+      },
+      include: {
+        ...includes,
+        avatar: true,
+        banner: true,
+        _count: {
+          select: {
+            bids: true
+          }
+        }
+      },
+      orderBy: {
+        [sort]: sortOrder
+      }
+    })
+    .withPages({
+      limit,
+      page
+    })
+
+  return { data, meta }
+}


### PR DESCRIPTION
Adds ability to search through different models

### Auction house
- [x] `GET /auction/listings/search?q=<query>`
  - Searches against `title` and `description`
- [x] `GET /auction/profiles/search?q=<query>`
  - Searches against `name` and `bio`

### Holidaze
- [x] `GET /holidaze/venues/search?q=<query>`
  - Searches against `name` and `description`
- [x] `GET /holidaze/profiles/search?q=<query>`
  - Searches against `name` and `bio`

### Social
- [x] `GET /social/posts/search?q=<query>`
  - Searches against `title` and `body`
- [x] `GET /social/profiles/search?q=<query>`
  - Searches against `name` and `bio`