### PR TITLE
docs/v2: misc updates + fixes

### DIFF
--- a/apps/docs/content/docs/v1/social/posts.mdx
+++ b/apps/docs/content/docs/v1/social/posts.mdx
@@ -103,14 +103,13 @@ You can filter based on an entry in the tags array by using the `_tag` query fla
 
 <TypeTable
   type={{
-    _tag: { type: "string", description: "Only posts matching tag." },
-    _active: { type: "boolean", description: "Only active posts." }
+    _tag: { type: "string", description: "Only posts matching tag." }
   }}
 />
 
-An example query filtering for active listings with the `my_tag` tag.
+An example query filtering for posts with the tag `my_tag`:
 
-<EndpointDetails path="/social/posts?_tag=my_tag&_active=true" />
+<EndpointDetails path="/social/posts?_tag=my_tag" />
 
 <Hr />
 

--- a/apps/docs/content/docs/v2/auction-house/listings.mdx
+++ b/apps/docs/content/docs/v2/auction-house/listings.mdx
@@ -353,3 +353,11 @@ Create new bid on a listing.
   "meta": {}
 }
 ```
+
+<Hr />
+
+## Search listings
+
+<EndpointDetails path="/auction/listings/search?q=<query>" />
+
+Search for listings by their `title` or `description` properties.

--- a/apps/docs/content/docs/v2/auction-house/profiles.mdx
+++ b/apps/docs/content/docs/v2/auction-house/profiles.mdx
@@ -435,3 +435,11 @@ The response is the same as the [listings](./listings#all-listings) endpoint, an
   }
 }
 ```
+
+<Hr />
+
+## Search profiles
+
+<EndpointDetails path="/auction/profiles/search?q=<query>" />
+
+Search for profiles by their `name` or `bio` properties.

--- a/apps/docs/content/docs/v2/holidaze/profiles.mdx
+++ b/apps/docs/content/docs/v2/holidaze/profiles.mdx
@@ -414,3 +414,11 @@ You may provide any combination of the properties, but at least one must be prov
   "meta": {}
 }
 ```
+
+<Hr />
+
+## Search profiles
+
+<EndpointDetails path="/holidaze/profiles/search?q=<query>" />
+
+Search for profiles by their `name` or `bio` properties.

--- a/apps/docs/content/docs/v2/holidaze/venues.mdx
+++ b/apps/docs/content/docs/v2/holidaze/venues.mdx
@@ -432,3 +432,11 @@ Updating a venue.
 Delete a venue based on its id.
 
 Returns an empty `204 No Content` response on success.
+
+<Hr />
+
+## Search venues
+
+<EndpointDetails path="/holidaze/venues/search?q=<query>" />
+
+Search for venues by their `name` or `description` properties.

--- a/apps/docs/content/docs/v2/social/posts.mdx
+++ b/apps/docs/content/docs/v2/social/posts.mdx
@@ -410,3 +410,11 @@ This endpoint allows a comment to be made on a post. The optional `replyToId` pr
   "meta": {}
 }
 ```
+
+<Hr />
+
+## Search posts
+
+<EndpointDetails path="/social/posts/search?q=<query>" />
+
+Search for posts by their `title` or `body` properties.

--- a/apps/docs/content/docs/v2/social/posts.mdx
+++ b/apps/docs/content/docs/v2/social/posts.mdx
@@ -141,14 +141,13 @@ You can filter based on an entry in the tags array by using the `_tag` query fla
 
 <TypeTable
   type={{
-    _tag: { type: "string", description: "Only posts matching tag." },
-    _active: { type: "boolean", description: "Only active posts." }
+    _tag: { type: "string", description: "Only posts matching tag." }
   }}
 />
 
-An example query filtering for active listings with the `my_tag` tag.
+An example query filtering for posts with the tag `my_tag`:
 
-<EndpointDetails path="/social/posts?_tag=my_tag&_active=true" />
+<EndpointDetails path="/social/posts?_tag=my_tag" />
 
 <Hr />
 

--- a/apps/docs/content/docs/v2/social/profiles.mdx
+++ b/apps/docs/content/docs/v2/social/profiles.mdx
@@ -364,3 +364,11 @@ Follow or unfollow another profile by its name.
   "meta": {}
 }
 ```
+
+<Hr />
+
+## Search profiles
+
+<EndpointDetails path="/social/profiles/search?q=<query>" />
+
+Search for profiles by their `name` or `bio` properties.

--- a/apps/v2/src/modules/auction/profiles/profiles.route.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.route.ts
@@ -66,7 +66,7 @@ async function profilesRoutes(server: FastifyInstance) {
     {
       onRequest: [server.authenticate, server.apiKey],
       schema: {
-        tags: ["auction-listings"],
+        tags: ["auction-profiles"],
         querystring: searchQuerySchema,
         response: {
           200: createResponseSchema(displayProfileSchema.array())


### PR DESCRIPTION
**Docs**
- Remove `_active` tag example in docs for social posts as it's incorrect.
- Adds docs for the new `/search` endpoint.

**API v2**
- Fixes incorrect swagger tag for auction profile `/search` endpoint.