### PR TITLE
v2/feat: Add delete social post comment

### DIFF
--- a/apps/docs/content/docs/v2/social/posts.mdx
+++ b/apps/docs/content/docs/v2/social/posts.mdx
@@ -408,6 +408,18 @@ This endpoint allows a comment to be made on a post. The optional `replyToId` pr
 
 <Hr />
 
+## Delete comment from post
+
+<EndpointDetails method="DELETE" path="/social/posts/<id>/comment/<comment-id>" />
+
+> Deleting a comment will also delete all replies to that comment.
+
+Delete a comment based on its id.
+
+Returns an empty `204 No Content` response on success.
+
+<Hr />
+
 ## Search posts
 
 <EndpointDetails path="/social/posts/search?q=<query>" />

--- a/apps/v1/src/modules/social/posts/posts.controller.ts
+++ b/apps/v1/src/modules/social/posts/posts.controller.ts
@@ -266,7 +266,7 @@ export async function deleteCommentHandler(
   const { id, commentId } = request.params
   const { name } = request.user as Profile
 
-  const post = await getPost(id)
+  const post = await getPost(id, { comments: true })
 
   if (!post) {
     throw new NotFound("Post not found")
@@ -276,6 +276,12 @@ export async function deleteCommentHandler(
 
   if (!comment) {
     throw new NotFound("Comment not found")
+  }
+
+  const isRelatedToPost = post.comments?.find(comment => comment.id === commentId)
+
+  if (!isRelatedToPost) {
+    throw new BadRequest("Comment is not related to this post")
   }
 
   if (name.toLowerCase() !== comment.owner.toLowerCase()) {

--- a/apps/v2/prisma/migrations/20231121140951_cascade_delete_comment_with_replies/migration.sql
+++ b/apps/v2/prisma/migrations/20231121140951_cascade_delete_comment_with_replies/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "SocialPostComment" DROP CONSTRAINT "SocialPostComment_replyToId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "SocialPostComment" ADD CONSTRAINT "SocialPostComment_replyToId_fkey" FOREIGN KEY ("replyToId") REFERENCES "SocialPostComment"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/v2/prisma/schema.prisma
+++ b/apps/v2/prisma/schema.prisma
@@ -243,7 +243,7 @@ model SocialPostComment {
   author    UserProfile         @relation(fields: [owner], references: [name], onDelete: Cascade)
   owner     String
   created   DateTime            @default(now())
-  replyTo   SocialPostComment?  @relation("Replies", fields: [replyToId], references: [id])
+  replyTo   SocialPostComment?  @relation("Replies", fields: [replyToId], references: [id], onDelete: Cascade)
   replies   SocialPostComment[] @relation("Replies")
   replyToId Int?
 }

--- a/apps/v2/src/modules/social/posts/__tests__/deleteComment.test.ts
+++ b/apps/v2/src/modules/social/posts/__tests__/deleteComment.test.ts
@@ -34,7 +34,7 @@ afterEach(async () => {
 })
 
 describe("[POST] /social/posts/:id/comment", () => {
-  it("should successfully add a comment to a post", async () => {
+  it("should successfully delete a comment", async () => {
     const { id: COMMENT_ID } = await db.socialPostComment.create({
       data: {
         body: "Test comment",
@@ -54,9 +54,7 @@ describe("[POST] /social/posts/:id/comment", () => {
 
     expect(response.statusCode).toBe(204)
 
-    const comments = await db.socialPostComment.findMany({
-      where: { id: COMMENT_ID }
-    })
+    const comments = await db.socialPostComment.findMany()
     expect(comments).toHaveLength(0)
   })
 

--- a/apps/v2/src/modules/social/posts/__tests__/deleteComment.test.ts
+++ b/apps/v2/src/modules/social/posts/__tests__/deleteComment.test.ts
@@ -1,0 +1,290 @@
+import { getAuthCredentials, server } from "@/test-utils"
+
+import { db } from "@/utils"
+
+const POST_ID = 1
+let BEARER_TOKEN = ""
+let API_KEY = ""
+let USER_NAME = ""
+
+beforeEach(async () => {
+  const { name, bearerToken, apiKey } = await getAuthCredentials()
+
+  BEARER_TOKEN = bearerToken
+  API_KEY = apiKey
+  USER_NAME = name
+
+  await db.socialPost.create({
+    data: {
+      id: POST_ID,
+      title: "Test post title",
+      owner: name
+    }
+  })
+})
+
+afterEach(async () => {
+  const users = db.userProfile.deleteMany()
+  const media = db.media.deleteMany()
+  const socialPostComment = db.socialPostComment.deleteMany()
+  const posts = db.socialPost.deleteMany()
+
+  await db.$transaction([users, media, socialPostComment, posts])
+  await db.$disconnect()
+})
+
+describe("[POST] /social/posts/:id/comment", () => {
+  it("should successfully add a comment to a post", async () => {
+    const { id: COMMENT_ID } = await db.socialPostComment.create({
+      data: {
+        body: "Test comment",
+        postId: POST_ID,
+        owner: USER_NAME
+      }
+    })
+
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/${COMMENT_ID}`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+
+    expect(response.statusCode).toBe(204)
+
+    const comments = await db.socialPostComment.findMany({
+      where: { id: COMMENT_ID }
+    })
+    expect(comments).toHaveLength(0)
+  })
+
+  it("should successfully delete a comment and its replies", async () => {
+    // Create a comment
+    const { id: COMMENT_ID } = await db.socialPostComment.create({
+      data: {
+        body: "Test comment",
+        postId: POST_ID,
+        owner: USER_NAME
+      }
+    })
+
+    // Create a reply to the comment
+    await db.socialPostComment.create({
+      data: {
+        body: "Test reply",
+        postId: POST_ID,
+        owner: USER_NAME,
+        replyToId: COMMENT_ID
+      }
+    })
+
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/${COMMENT_ID}`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+
+    expect(response.statusCode).toBe(204)
+
+    // Check that the comment and its reply have been deleted
+    const comments = await db.socialPostComment.findMany()
+    expect(comments).toHaveLength(0)
+  })
+
+  it("should only delete replies that are related to the comment", async () => {
+    // Create a comment
+    await db.socialPostComment.create({
+      data: {
+        body: "Test comment",
+        postId: POST_ID,
+        owner: USER_NAME
+      }
+    })
+
+    // Create a comment that will receive a reply
+    const { id: COMMENT_ID } = await db.socialPostComment.create({
+      data: {
+        body: "Test comment with reply",
+        postId: POST_ID,
+        owner: USER_NAME
+      }
+    })
+
+    // Create a reply to the comment that will be deleted
+    await db.socialPostComment.create({
+      data: {
+        body: "Test reply",
+        postId: POST_ID,
+        owner: USER_NAME,
+        replyToId: COMMENT_ID
+      }
+    })
+
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/${COMMENT_ID}`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+
+    expect(response.statusCode).toBe(204)
+
+    // Check that the comment and its reply have been deleted
+    const comments = await db.socialPostComment.findMany()
+    expect(comments).toHaveLength(1)
+    expect(comments[0].body).toBe("Test comment")
+  })
+
+  it("should throw zod error when attempting to delete a comment with an invalid id", async () => {
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/1.2`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      code: "invalid_type",
+      message: "Comment ID must be an integer",
+      path: ["commentId"]
+    })
+  })
+
+  it("should throw 400 when attempting to delete a comment that's not related to the post", async () => {
+    // Create another post with id 2
+    const SECOND_POST_ID = 2
+    await db.socialPost.create({
+      data: {
+        id: SECOND_POST_ID,
+        title: "Test post title",
+        owner: USER_NAME
+      }
+    })
+
+    // Create a comment on post 2
+    const { id: COMMENT_ID } = await db.socialPostComment.create({
+      data: {
+        body: "Test comment",
+        postId: SECOND_POST_ID,
+        owner: USER_NAME
+      }
+    })
+
+    // Try to delete the comment on post 2 through post 1
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/${COMMENT_ID}`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "Comment is not related to this post"
+    })
+  })
+
+  it("should throw 404 when attempting to delete a non-existent comment", async () => {
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/1`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(404)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "Comment not found"
+    })
+  })
+
+  it("should throw 404 error when attempting to delete a comment on a non-existent post", async () => {
+    const response = await server.inject({
+      url: `/social/posts/3/comment/1`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(404)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "Post not found"
+    })
+  })
+
+  it("should throw 401 error when attempting to delete without API key", async () => {
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/1`,
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(401)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "No API key header was found"
+    })
+  })
+
+  it("should throw 401 error when attempting to delete without Bearer token", async () => {
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}/comment/1`,
+      method: "DELETE",
+      headers: {
+        "X-Noroff-API-Key": API_KEY
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(401)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toBeDefined()
+    expect(res.errors).toHaveLength(1)
+    expect(res.errors[0]).toStrictEqual({
+      message: "No authorization header was found"
+    })
+  })
+})

--- a/apps/v2/src/modules/social/posts/posts.controller.ts
+++ b/apps/v2/src/modules/social/posts/posts.controller.ts
@@ -325,7 +325,7 @@ export async function deleteCommentHandler(
   const { id, commentId } = await deleteCommentSchema.parseAsync(request.params)
   const { name } = request.user as UserProfile
 
-  const post = await getPost(id, { author: true, comments: true })
+  const post = await getPost(id, { comments: true })
 
   if (!post.data) {
     throw new NotFound("Post not found")

--- a/apps/v2/src/modules/social/posts/posts.controller.ts
+++ b/apps/v2/src/modules/social/posts/posts.controller.ts
@@ -7,6 +7,7 @@ import {
   authorQuerySchema,
   CreateCommentSchema,
   CreatePostBaseSchema,
+  deleteCommentSchema,
   emojiSchema,
   mediaSchema,
   postIdParamsSchema,
@@ -17,6 +18,7 @@ import {
   createComment,
   createOrDeleteReaction,
   createPost,
+  deleteCommentAndReplies,
   deletePost,
   getComment,
   getPost,
@@ -309,4 +311,43 @@ export async function searchPostsHandler(
   const results = await searchPosts(sort, sortOrder, limit, page, q, includes)
 
   return results
+}
+
+export async function deleteCommentHandler(
+  request: FastifyRequest<{
+    Params: {
+      id: number
+      commentId: number
+    }
+  }>,
+  reply: FastifyReply
+) {
+  const { id, commentId } = await deleteCommentSchema.parseAsync(request.params)
+  const { name } = request.user as UserProfile
+
+  const post = await getPost(id, { author: true, comments: true })
+
+  if (!post.data) {
+    throw new NotFound("Post not found")
+  }
+
+  const comment = await getComment(commentId)
+
+  if (!comment) {
+    throw new NotFound("Comment not found")
+  }
+
+  const isRelatedToPost = post.data.comments?.find(comment => comment.id === commentId)
+
+  if (!isRelatedToPost) {
+    throw new BadRequest("Comment is not related to this post")
+  }
+
+  if (name.toLowerCase() !== comment.owner.toLowerCase()) {
+    throw new Forbidden("You do not have permission to delete this comment")
+  }
+
+  await deleteCommentAndReplies(commentId)
+
+  reply.code(204)
 }

--- a/apps/v2/src/modules/social/posts/posts.route.ts
+++ b/apps/v2/src/modules/social/posts/posts.route.ts
@@ -5,6 +5,7 @@ import {
   createCommentHandler,
   createOrDeleteReactionHandler,
   createPostHandler,
+  deleteCommentHandler,
   deletePostHandler,
   getPostHandler,
   getPostsHandler,
@@ -16,6 +17,7 @@ import {
   authorQuerySchema,
   createCommentSchema,
   createPostBaseSchema,
+  deleteCommentSchema,
   displayCommentSchema,
   displayPostSchema,
   postIdParamsSchema,
@@ -172,6 +174,19 @@ async function postsRoutes(server: FastifyInstance) {
       }
     },
     createCommentHandler
+  )
+
+  server.delete(
+    "/:id/comment/:commentId",
+    {
+      preHandler: [server.authenticate, server.apiKey],
+      schema: {
+        tags: ["social-posts"],
+        security: [{ bearerAuth: [] }],
+        params: deleteCommentSchema
+      }
+    },
+    deleteCommentHandler
   )
 }
 

--- a/apps/v2/src/modules/social/posts/posts.schema.ts
+++ b/apps/v2/src/modules/social/posts/posts.schema.ts
@@ -68,10 +68,19 @@ const postId = {
 export const postIdParamsSchema = z.object({
   id: z.coerce
     .number({
-      invalid_type_error: "ID must be a number"
+      invalid_type_error: "Post ID must be a number"
     })
-    .int("ID must be an integer")
-    .positive("ID must be a positive integer")
+    .int("Post ID must be an integer")
+    .positive("Post ID must be a positive integer")
+})
+
+export const deleteCommentSchema = postIdParamsSchema.extend({
+  commentId: z.coerce
+    .number({
+      invalid_type_error: "Comment ID must be a number"
+    })
+    .int("Comment ID must be an integer")
+    .positive("Comment ID must be a positive integer")
 })
 
 const postMeta = {

--- a/apps/v2/src/modules/social/posts/posts.service.ts
+++ b/apps/v2/src/modules/social/posts/posts.service.ts
@@ -293,7 +293,7 @@ export const createComment = async (
   return { data }
 }
 
-export const deleteComment = async (id: number) => {
+export const deleteCommentAndReplies = async (id: number) => {
   await db.socialPostComment.delete({
     where: { id }
   })


### PR DESCRIPTION
v2: 
- Adds ability to delete comments from social posts through `DELETE /social/post/:postId/comment/:commentId`.
  - Deleted comments also deletes replies to that comment. Similarly to how it works on v1.
- Adds docs for delete endpoint

v1: 
- Adds missing check for if the comment requesting to be deleted is related to the post from the same query.
