### PR TITLE
Add/fix missing media includes

### DIFF
--- a/apps/v2/src/exceptions/errorHandler.ts
+++ b/apps/v2/src/exceptions/errorHandler.ts
@@ -40,7 +40,7 @@ const httpErrorHandler: ErrorHandlerStrategy = error => {
 }
 
 const jwtErrorHandler: ErrorHandlerStrategy = error => {
-  if (error.code.startsWith("FST_JWT")) {
+  if (error.code?.startsWith("FST_JWT")) {
     let statusCode: number
     let customMessage: string
 

--- a/apps/v2/src/modules/social/posts/posts.service.ts
+++ b/apps/v2/src/modules/social/posts/posts.service.ts
@@ -122,7 +122,6 @@ export const createPost = async (createPostData: CreatePostSchema, includes: Soc
   const withCommentAuthor = includes.comments
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
-  const withMedia = media?.url ? { media: true } : {}
   const withAuthorMedia = includes.author ? { author: { include: { avatar: true, banner: true } } } : {}
 
   const data = await db.socialPost.create({
@@ -133,8 +132,8 @@ export const createPost = async (createPostData: CreatePostSchema, includes: Soc
     include: {
       ...includes,
       ...withCommentAuthor,
-      ...withMedia,
       ...withAuthorMedia,
+      media: true,
       _count: {
         select: {
           comments: true,
@@ -156,7 +155,6 @@ export const updatePost = async (
   const withCommentAuthor = includes.comments
     ? { comments: { include: { author: { include: { avatar: true, banner: true } } } } }
     : {}
-  const withMedia = media?.url ? { media: true } : {}
 
   const data = await db.socialPost.update({
     data: {
@@ -167,7 +165,7 @@ export const updatePost = async (
     include: {
       ...includes,
       ...withCommentAuthor,
-      ...withMedia,
+      media: true,
       _count: {
         select: {
           comments: true,

--- a/apps/v2/src/modules/social/profiles/profiles.service.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.service.ts
@@ -180,6 +180,7 @@ export const getProfilePosts = async (
         ...includes,
         ...withCommentAuthor,
         ...withAuthorMedia,
+        media: true,
         _count: {
           select: {
             comments: true,


### PR DESCRIPTION
- Add missing media includes.
- Previously media was only returned if the POST/PUT included the media field. This is now always returned instead.
- Adds `?` to jwtErrorHandler as the `error.code` property isn't always present.