### PR TITLE
Fix typo in v1 _bids_ property name

### DIFF
--- a/apps/docs/content/docs/v1/auction-house/listings.mdx
+++ b/apps/docs/content/docs/v1/auction-house/listings.mdx
@@ -40,7 +40,7 @@ Not all of the properties of a listing are returned by default. You can use the 
 <TypeTable
   type={{
     _seller: { type: "boolean", default: "false", description: "Include seller." },
-    _bids_: { type: "boolean", default: "false", description: "Include bids." }
+    _bids: { type: "boolean", default: "false", description: "Include bids." }
   }}
 />
 


### PR DESCRIPTION
An oversight was made. I thought there was one block managing both versions but there was two. 
This adds fix to V1 spelling error.