### PR TITLE
Update profile bio, min length for titles, index route info

### DIFF
--- a/apps/docs/content/docs/v2/auction-house/profiles.mdx
+++ b/apps/docs/content/docs/v2/auction-house/profiles.mdx
@@ -199,14 +199,15 @@ Retrieve a single profile by its id.
 
 <EndpointDetails method="PUT" path="/auction/profiles/<name>" />
 
-Update or set profile `banner` and `avatar` images.
+Update or set `bio`, `banner` and `avatar` properties.
 
-You can send either or both of the properties in the request body.
+You may provide any combination of the properties, but at least one must be provided.
 
 > Please note that the `avatar.url` and `banner.url` properties must be fully formed URLs that links to live and publicly accessible images. The API will check the provided URLs and if they cannot be accessed publicly you will receive a `400 Bad Request` error response.
 
 ```json title="Request"
 {
+  "bio": "string",
   "avatar": {
     "url": "https://picsum.photos/id/135/800/800",
     "alt": ""

--- a/apps/docs/content/docs/v2/holidaze/profiles.mdx
+++ b/apps/docs/content/docs/v2/holidaze/profiles.mdx
@@ -370,7 +370,7 @@ The response is the same as the [venues](./venues#all-venues) endpoint, and acce
 
 <EndpointDetails method="PUT" path="/holidaze/profiles/<name>" />
 
-Update or set `venueManager` boolean, `avatar` and/or `banner` image.
+Update or set `bio`, `venueManager`, `banner` and `avatar` properties.
 
 You may provide any combination of the properties, but at least one must be provided.
 
@@ -378,7 +378,7 @@ You may provide any combination of the properties, but at least one must be prov
 
 ```json title="Request"
 {
-  "venueManager": true,
+  "bio": "string",
   "avatar": {
     "url": "https://url.com/image.jpg",
     "alt": "string"
@@ -386,7 +386,8 @@ You may provide any combination of the properties, but at least one must be prov
   "banner": {
     "url": "https://url.com/image.jpg",
     "alt": "string"
-  }
+  },
+  "venueManager": true
 }
 ```
 

--- a/apps/docs/content/docs/v2/social/profiles.mdx
+++ b/apps/docs/content/docs/v2/social/profiles.mdx
@@ -273,14 +273,15 @@ The response is the same as the [posts](./posts#all-posts) endpoint, and accepts
 
 <EndpointDetails method="PUT" path="/social/profiles/<name>" />
 
-Update or set profile `banner` and `avatar` images.
+Update or set `bio`, `banner` and `avatar` properties.
 
-You can send either or both of the properties in the request body.
+You may provide any combination of the properties, but at least one must be provided.
 
 > Please note that the `avatar.url` and `banner.url` properties must be fully formed URLs that links to live and publicly accessible images. The API will check the provided URLs and if they cannot be accessed publicly you will receive a `400 Bad Request` error response.
 
 ```json title="Request"
 {
+  "bio": "string",
   "banner": {
     "url": "https://url.com/image.jpg",
     "alt": "string"

--- a/apps/v1/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v1/src/modules/auction/listings/listings.schema.ts
@@ -66,6 +66,7 @@ export const createListingSchema = z.object({
       required_error: "Title is required",
       invalid_type_error: "Title must be a string"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim(),
   description: z
@@ -104,6 +105,7 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v1/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v1/src/modules/auction/listings/listings.schema.ts
@@ -105,7 +105,6 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v1/src/modules/index/index.route.ts
+++ b/apps/v1/src/modules/index/index.route.ts
@@ -1,0 +1,22 @@
+import { FastifyInstance } from "fastify"
+
+async function indexRoutes(server: FastifyInstance) {
+  server.get(
+    "/",
+    {
+      schema: {
+        hide: true
+      }
+    },
+    () => {
+      return {
+        message: "Welcome to the Noroff API v1!",
+        github: "https://github.com/Noroff-Online-Team/noroff-api",
+        docs: "https://docs.noroff.dev/docs/v1",
+        swagger: "https://api.noroff.dev/docs"
+      }
+    }
+  )
+}
+
+export default indexRoutes

--- a/apps/v1/src/modules/social/posts/posts.schema.ts
+++ b/apps/v1/src/modules/social/posts/posts.schema.ts
@@ -26,6 +26,7 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim(),
   body: z
@@ -43,6 +44,7 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v1/src/modules/social/posts/posts.schema.ts
+++ b/apps/v1/src/modules/social/posts/posts.schema.ts
@@ -44,7 +44,6 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v1/src/server.ts
+++ b/apps/v1/src/server.ts
@@ -5,6 +5,7 @@ import { serializerCompiler, validatorCompiler, ZodTypeProvider } from "fastify-
 
 import errorHandler from "./exceptions/errorHandler"
 import notFoundHandler from "./exceptions/notFoundHandler"
+import indexRoutes from "./modules/index/index.route"
 import routes from "./modules/routes"
 import statusRoutes from "./modules/status/status.route"
 
@@ -39,6 +40,9 @@ function buildServer() {
 
   // Set custom not found handler to match our error format
   server.setNotFoundHandler(notFoundHandler)
+
+  // Register index route
+  server.register(indexRoutes)
 
   // Register status route
   server.register(statusRoutes, { prefix: "status" })

--- a/apps/v2/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v2/src/modules/auction/listings/listings.schema.ts
@@ -60,6 +60,7 @@ export const createListingSchema = z.object({
       required_error: "Title is required",
       invalid_type_error: "Title must be a string"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim(),
   description: z
@@ -98,6 +99,7 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v2/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v2/src/modules/auction/listings/listings.schema.ts
@@ -99,7 +99,6 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v2/src/modules/auction/profiles/__tests__/updateProfile.test.ts
+++ b/apps/v2/src/modules/auction/profiles/__tests__/updateProfile.test.ts
@@ -10,7 +10,8 @@ const updateData = {
   banner: {
     url: "https://picsum.photos/id/888/1500/500",
     alt: ""
-  }
+  },
+  bio: "This is a test bio"
 }
 
 let BEARER_TOKEN = ""
@@ -59,6 +60,7 @@ describe("[PUT] /auction/profiles/:id", () => {
       url: "https://picsum.photos/id/888/1500/500",
       alt: ""
     })
+    expect(res.data.bio).toStrictEqual("This is a test bio")
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })
@@ -86,6 +88,48 @@ describe("[PUT] /auction/profiles/:id", () => {
       alt: "A blurry multi-colored rainbow background"
     })
     expect(res.data).toBeDefined()
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should successfully update the profile bio", async () => {
+    const response = await server.inject({
+      url: `/auction/profiles/${TEST_USER_NAME}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        bio: "This is a test bio"
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data.bio).toStrictEqual("This is a test bio")
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should successfully remove the profile bio by setting it to null", async () => {
+    const response = await server.inject({
+      url: `/auction/profiles/${TEST_USER_NAME}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        bio: null
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data.bio).toBeNull()
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })

--- a/apps/v2/src/modules/auction/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.controller.ts
@@ -88,7 +88,7 @@ export async function updateProfileHandler(
     Body: UpdateProfileSchema
   }>
 ) {
-  const { avatar, banner } = await updateProfileSchema.parseAsync(request.body)
+  const { avatar, banner, bio } = await updateProfileSchema.parseAsync(request.body)
   const { name: profileToUpdate } = await profileNameSchema.parseAsync(request.params)
   const { name: requesterProfile } = request.user as UserProfile
 
@@ -109,7 +109,7 @@ export async function updateProfileHandler(
     await mediaGuard(banner.url)
   }
 
-  const profile = await updateProfile(profileToUpdate, { avatar, banner })
+  const profile = await updateProfile(profileToUpdate, { avatar, banner, bio })
 
   return profile
 }

--- a/apps/v2/src/modules/auction/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.controller.ts
@@ -88,7 +88,7 @@ export async function updateProfileHandler(
     Body: UpdateProfileSchema
   }>
 ) {
-  const { avatar, banner, bio } = await updateProfileSchema.parseAsync(request.body)
+  const { avatar, banner, ...rest } = await updateProfileSchema.parseAsync(request.body)
   const { name: profileToUpdate } = await profileNameSchema.parseAsync(request.params)
   const { name: requesterProfile } = request.user as UserProfile
 
@@ -109,7 +109,7 @@ export async function updateProfileHandler(
     await mediaGuard(banner.url)
   }
 
-  const profile = await updateProfile(profileToUpdate, { avatar, banner, bio })
+  const profile = await updateProfile(profileToUpdate, { avatar, banner, ...rest })
 
   return profile
 }

--- a/apps/v2/src/modules/auction/profiles/profiles.schema.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.schema.ts
@@ -1,9 +1,12 @@
 import { sortAndPaginationSchema } from "@noroff/api-utils"
 import { z } from "zod"
 
-import { mediaProperties, profileCore, profileMedia } from "../../auth/auth.schema"
+import { mediaProperties, profileBio, profileCore, profileMedia } from "../../auth/auth.schema"
 
-export const updateProfileSchema = z.object(profileMedia)
+export const updateProfileSchema = z.object({
+  ...profileMedia,
+  ...profileBio
+})
 
 const profileCredits = {
   credits: z

--- a/apps/v2/src/modules/auction/profiles/profiles.service.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.service.ts
@@ -71,10 +71,11 @@ export async function getProfile(name: string, includes: AuctionProfileIncludes 
   return { data: data[0] }
 }
 
-export const updateProfile = async (name: string, { avatar, banner }: UpdateProfileSchema) => {
+export const updateProfile = async (name: string, { avatar, banner, ...updateData }: UpdateProfileSchema) => {
   const data = await db.userProfile.update({
     where: { name },
     data: {
+      ...updateData,
       avatar: avatar ? { delete: {}, create: avatar } : undefined,
       banner: banner ? { delete: {}, create: banner } : undefined
     },

--- a/apps/v2/src/modules/auth/auth.schema.ts
+++ b/apps/v2/src/modules/auth/auth.schema.ts
@@ -48,6 +48,10 @@ export const profileMedia = {
   banner: z.object(mediaPropertiesWithErrors).optional()
 }
 
+export const profileBio = {
+  bio: z.string().max(160, "Bio cannot be greater than 160 characters").trim().nullish()
+}
+
 export const profileCore = {
   name: z
     .string({

--- a/apps/v2/src/modules/holidaze/profiles/__tests__/updateProfile.test.ts
+++ b/apps/v2/src/modules/holidaze/profiles/__tests__/updateProfile.test.ts
@@ -10,7 +10,8 @@ const updateData = {
   banner: {
     url: "https://picsum.photos/id/888/1500/500",
     alt: ""
-  }
+  },
+  bio: "This is a test bio"
 }
 
 let BEARER_TOKEN = ""
@@ -59,6 +60,7 @@ describe("[PUT] /holidaze/profiles/:id", () => {
       url: "https://picsum.photos/id/888/1500/500",
       alt: ""
     })
+    expect(res.data.bio).toStrictEqual("This is a test bio")
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })
@@ -86,6 +88,48 @@ describe("[PUT] /holidaze/profiles/:id", () => {
       alt: "A blurry multi-colored rainbow background"
     })
     expect(res.data).toBeDefined()
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should successfully update the profile bio", async () => {
+    const response = await server.inject({
+      url: `/holidaze/profiles/${TEST_USER_NAME}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        bio: "This is a test bio"
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data.bio).toStrictEqual("This is a test bio")
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should successfully remove the profile bio by setting it to null", async () => {
+    const response = await server.inject({
+      url: `/holidaze/profiles/${TEST_USER_NAME}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        bio: null
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data.bio).toBeNull()
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })

--- a/apps/v2/src/modules/holidaze/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/holidaze/profiles/profiles.controller.ts
@@ -88,7 +88,7 @@ export async function updateProfileHandler(
     Body: UpdateProfileSchema
   }>
 ) {
-  const { venueManager, banner, avatar } = await updateProfileSchema.parseAsync(request.body)
+  const { banner, avatar, ...rest } = await updateProfileSchema.parseAsync(request.body)
   const { name: profileToUpdate } = await profileNameSchema.parseAsync(request.params)
   const { name: requesterProfile } = request.user as UserProfile
 
@@ -109,7 +109,7 @@ export async function updateProfileHandler(
     await mediaGuard(banner.url)
   }
 
-  const updatedProfile = await updateProfile(profileToUpdate, { venueManager, banner, avatar })
+  const updatedProfile = await updateProfile(profileToUpdate, { banner, avatar, ...rest })
 
   return updatedProfile
 }

--- a/apps/v2/src/modules/holidaze/profiles/profiles.schema.ts
+++ b/apps/v2/src/modules/holidaze/profiles/profiles.schema.ts
@@ -1,7 +1,7 @@
 import { sortAndPaginationSchema } from "@noroff/api-utils"
 import { z } from "zod"
 
-import { profileCore, profileMedia } from "../../auth/auth.schema"
+import { profileBio, profileCore, profileMedia } from "../../auth/auth.schema"
 import { bookingCore } from "../bookings/bookings.schema"
 import { venueCore } from "../venues/venues.schema"
 
@@ -15,7 +15,8 @@ const profileVenueManager = {
 
 export const updateProfileSchema = z.object({
   ...profileMedia,
-  ...profileVenueManager
+  ...profileVenueManager,
+  ...profileBio
 })
 
 export const holidazeProfileSchema = z.object(profileCore).extend(profileVenueManager)

--- a/apps/v2/src/modules/index/index.route.ts
+++ b/apps/v2/src/modules/index/index.route.ts
@@ -1,0 +1,22 @@
+import { FastifyInstance } from "fastify"
+
+async function indexRoutes(server: FastifyInstance) {
+  server.get(
+    "/",
+    {
+      schema: {
+        hide: true
+      }
+    },
+    () => {
+      return {
+        message: "Welcome to the Noroff API v2!",
+        github: "https://github.com/Noroff-Online-Team/noroff-api",
+        docs: "https://docs.noroff.dev/docs/v2",
+        swagger: "https://v2.api.noroff.dev/docs"
+      }
+    }
+  )
+}
+
+export default indexRoutes

--- a/apps/v2/src/modules/routes.ts
+++ b/apps/v2/src/modules/routes.ts
@@ -1,6 +1,7 @@
 import type { FastifyInstance } from "fastify"
 
 export default async function (fastify: FastifyInstance) {
+  fastify.register(import("./index/index.route"))
   fastify.register(import("./status/status.route"), { prefix: "status" })
   fastify.register(import("./books/books.route"), { prefix: "books" })
   fastify.register(import("./catFacts/catFacts.route"), { prefix: "cat-facts" })

--- a/apps/v2/src/modules/social/posts/posts.schema.ts
+++ b/apps/v2/src/modules/social/posts/posts.schema.ts
@@ -27,6 +27,7 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim(),
   body: z
@@ -44,6 +45,7 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v2/src/modules/social/posts/posts.schema.ts
+++ b/apps/v2/src/modules/social/posts/posts.schema.ts
@@ -45,7 +45,6 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .min(1, "Title cannot be empty")
     .max(280, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),

--- a/apps/v2/src/modules/social/profiles/__tests__/updateProfile.test.ts
+++ b/apps/v2/src/modules/social/profiles/__tests__/updateProfile.test.ts
@@ -10,7 +10,8 @@ const updateData = {
   banner: {
     url: "https://picsum.photos/id/888/1500/500",
     alt: ""
-  }
+  },
+  bio: "This is a test bio"
 }
 
 let BEARER_TOKEN = ""
@@ -59,6 +60,7 @@ describe("[PUT] /social/profiles/:id", () => {
       url: "https://picsum.photos/id/888/1500/500",
       alt: ""
     })
+    expect(res.data.bio).toStrictEqual("This is a test bio")
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })
@@ -86,6 +88,48 @@ describe("[PUT] /social/profiles/:id", () => {
       alt: "A blurry multi-colored rainbow background"
     })
     expect(res.data).toBeDefined()
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should successfully update the profile bio", async () => {
+    const response = await server.inject({
+      url: `/social/profiles/${TEST_USER_NAME}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        bio: "This is a test bio"
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data.bio).toStrictEqual("This is a test bio")
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should successfully remove the profile bio by setting it to null", async () => {
+    const response = await server.inject({
+      url: `/social/profiles/${TEST_USER_NAME}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        bio: null
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data.bio).toBeNull()
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })

--- a/apps/v2/src/modules/social/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.controller.ts
@@ -98,7 +98,7 @@ export async function updateProfileHandler(
     Body: UpdateProfileSchema
   }>
 ) {
-  const { avatar, banner } = updateProfileSchema.parse(request.body)
+  const { avatar, banner, ...rest } = updateProfileSchema.parse(request.body)
   const { name: profileToUpdate } = profileNameSchema.parse(request.params)
   const { name: requesterProfile } = request.user as UserProfile
 
@@ -119,7 +119,7 @@ export async function updateProfileHandler(
     await mediaGuard(banner.url)
   }
 
-  const profile = await updateProfile(profileToUpdate, { avatar, banner })
+  const profile = await updateProfile(profileToUpdate, { avatar, banner, ...rest })
 
   return profile
 }

--- a/apps/v2/src/modules/social/profiles/profiles.schema.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.schema.ts
@@ -1,10 +1,13 @@
 import { sortAndPaginationSchema } from "@noroff/api-utils"
 import { z } from "zod"
 
-import { profileCore, profileMedia } from "../../auth/auth.schema"
+import { profileBio, profileCore, profileMedia } from "../../auth/auth.schema"
 import { postSchema } from "../posts/posts.schema"
 
-export const updateProfileSchema = z.object(profileMedia)
+export const updateProfileSchema = z.object({
+  ...profileMedia,
+  ...profileBio
+})
 export const profileSchema = z.object(profileCore)
 
 export const profileNameSchema = z.object({

--- a/apps/v2/src/modules/social/profiles/profiles.service.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.service.ts
@@ -77,10 +77,11 @@ export const getProfile = async (name: string, includes: ProfileIncludes = {}) =
   return { data: data[0] }
 }
 
-export const updateProfile = async (name: string, { avatar, banner }: UpdateProfileSchema) => {
+export const updateProfile = async (name: string, { avatar, banner, ...updateData }: UpdateProfileSchema) => {
   const data = await db.userProfile.update({
     where: { name },
     data: {
+      ...updateData,
       avatar: avatar ? { delete: {}, create: avatar } : undefined,
       banner: banner ? { delete: {}, create: banner } : undefined
     },


### PR DESCRIPTION
Some fixes and updates. Decided to stick them all in a single PR.

- Adds ability to update user profile bio.
- Social post and auction listings now have 1 character min length requirement for titles. 
  - I've fixed this for both v1 and v2 so they match.
  - I have manually added "Default title" to any that didn't have a title in the database.
- Adds github, docs, and swagger links to the index route for both v1 and v2 APIs.

Closes #162
Closes #163
Closes #164