### PR TITLE
Fix updating post & listing titles

### DIFF
--- a/apps/v1/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v1/src/modules/auction/listings/listings.schema.ts
@@ -2,6 +2,13 @@ import { z } from "zod"
 
 import { displayProfileSchema } from "../profiles/profiles.schema"
 
+const LISTING_TITLE_MIN_LENGTH = 1
+const LISTING_TITLE_MAX_LENGTH = 280
+const LISTING_DESCRIPTION_MAX_LENGTH = 280
+const LISTING_TAGS_MAX_LENGTH = 24
+const LISTING_MAX_TAGS = 8
+const LISTING_MAX_IMAGES = 8
+
 const listingId = {
   id: z.string().uuid()
 }
@@ -44,9 +51,9 @@ const tagsAndMedia = {
       .string({
         invalid_type_error: "Tags must be an array of strings"
       })
-      .max(24, "Tags cannot be greater than 24 characters")
+      .max(LISTING_TAGS_MAX_LENGTH, "Tags cannot be greater than 24 characters")
       .array()
-      .max(8, "You cannot have more than 8 tags"),
+      .max(LISTING_MAX_TAGS, "You cannot have more than 8 tags"),
     z.undefined()
   ]),
   media: z
@@ -55,7 +62,7 @@ const tagsAndMedia = {
     })
     .url("Image must be valid URL")
     .array()
-    .max(8, "You cannot have more than 8 images")
+    .max(LISTING_MAX_IMAGES, "You cannot have more than 8 images")
     .nullish()
     .or(z.literal(""))
 }
@@ -66,14 +73,14 @@ export const createListingSchema = z.object({
       required_error: "Title is required",
       invalid_type_error: "Title must be a string"
     })
-    .min(1, "Title cannot be empty")
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim(),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(280, "Description cannot be greater than 280 characters")
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
     .nullish(),
   endsAt: z
@@ -105,14 +112,15 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(280, "Description cannot be greater than 280 characters")
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -120,10 +128,7 @@ export const updateListingCore = {
 
 export const updateListingSchema = z
   .object(updateListingCore)
-  .refine(
-    ({ title, description, media, tags }) => !!title || !!description || !!media || !!tags,
-    "You must provide either title, description, media, or tags"
-  )
+  .refine(data => Object.keys(data).length > 0, "You must provide at least one field to update")
 
 const queryFlagsCore = {
   _seller: z.preprocess(val => String(val).toLowerCase() === "true", z.boolean()).optional(),

--- a/apps/v1/src/modules/social/posts/posts.schema.ts
+++ b/apps/v1/src/modules/social/posts/posts.schema.ts
@@ -1,14 +1,21 @@
 import { z } from "zod"
 
+const POST_TITLE_MIN_LENGTH = 1
+const POST_TITLE_MAX_LENGTH = 280
+const POST_BODY_MAX_LENGTH = 280
+const POST_TAGS_MAX_LENGTH = 24
+const POST_MAX_TAGS = 8
+const COMMENT_BODY_MAX_LENGTH = 280
+
 const tagsAndMedia = {
   tags: z.union([
     z
       .string({
         invalid_type_error: "Tags must be an array of strings"
       })
-      .max(24, "Tags cannot be greater than 24 characters")
+      .max(POST_TAGS_MAX_LENGTH, "Tags cannot be greater than 24 characters")
       .array()
-      .max(8, "You cannot have more than 8 tags"),
+      .max(POST_MAX_TAGS, "You cannot have more than 8 tags"),
     z.undefined()
   ]),
   media: z
@@ -26,14 +33,14 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
-    .min(1, "Title cannot be empty")
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(280, "Body cannot be greater than 280 characters")
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -44,14 +51,15 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(280, "Body cannot be greater than 280 characters")
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -113,7 +121,7 @@ const commentCore = {
       invalid_type_error: "Body must be a string",
       required_error: "Body is required"
     })
-    .max(280, "Body cannot be greater than 280 characters")
+    .max(COMMENT_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim(),
   replyToId: z
     .number({
@@ -156,10 +164,7 @@ export const createPostBaseSchema = z.object(postCore)
 
 export const updatePostBodySchema = z
   .object(updatePostCore)
-  .refine(
-    ({ title, body, tags, media }) => !!title || !!body || !!tags || !!media,
-    "You must provide either title, body, tags, or media"
-  )
+  .refine(data => Object.keys(data).length > 0, "You must provide at least one field to update")
 
 export const createPostSchema = z.object({
   ...postOwner,

--- a/apps/v2/src/modules/auction/listings/__tests__/updateListing.test.ts
+++ b/apps/v2/src/modules/auction/listings/__tests__/updateListing.test.ts
@@ -117,8 +117,35 @@ describe("[PUT] /auction/listings/:id", () => {
     expect(res.errors).toStrictEqual([
       {
         code: "custom",
-        message: "You must provide either title, description, media, or tags",
+        message: "You must provide at least one field to update",
         path: []
+      }
+    ])
+  })
+
+  it("should throw zod error if attempting to update with an empty title", async () => {
+    const response = await server.inject({
+      url: `/auction/listings/${LISTING_ID}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        title: "",
+        endsAt: new Date(new Date().setMonth(new Date().getMonth() + 1))
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toStrictEqual([
+      {
+        code: "too_small",
+        message: "Title cannot be empty",
+        path: ["title"]
       }
     ])
   })

--- a/apps/v2/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v2/src/modules/auction/listings/listings.schema.ts
@@ -4,6 +4,12 @@ import { z } from "zod"
 import { mediaProperties, mediaPropertiesWithErrors, profileCore } from "../../auth/auth.schema"
 import { displayProfileSchema } from "../profiles/profiles.schema"
 
+const LISTING_TITLE_MIN_LENGTH = 1
+const LISTING_TITLE_MAX_LENGTH = 280
+const LISTING_DESCRIPTION_MAX_LENGTH = 280
+const LISTING_TAGS_MAX_LENGTH = 24
+const LISTING_MAX_TAGS = 8
+
 const bidCore = {
   id: z.string().uuid(),
   amount: z.number(),
@@ -47,9 +53,9 @@ const tagsAndMedia = {
     .string({
       invalid_type_error: "Tags must be an array of strings"
     })
-    .max(24, "Tags cannot be greater than 24 characters")
+    .max(LISTING_TAGS_MAX_LENGTH, "Tags cannot be greater than 24 characters")
     .array()
-    .max(8, "You cannot have more than 8 tags")
+    .max(LISTING_MAX_TAGS, "You cannot have more than 8 tags")
     .optional(),
   media: z.object(mediaPropertiesWithErrors).array().max(8, "You cannot have more than 8 images").nullish()
 }
@@ -60,14 +66,14 @@ export const createListingSchema = z.object({
       required_error: "Title is required",
       invalid_type_error: "Title must be a string"
     })
-    .min(1, "Title cannot be empty")
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim(),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(280, "Description cannot be greater than 280 characters")
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
     .nullish(),
   endsAt: z
@@ -99,14 +105,15 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(280, "Description cannot be greater than 280 characters")
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -114,10 +121,7 @@ export const updateListingCore = {
 
 export const updateListingSchema = z
   .object(updateListingCore)
-  .refine(
-    ({ title, description, media, tags }) => !!title || !!description || !!media || !!tags,
-    "You must provide either title, description, media, or tags"
-  )
+  .refine(data => Object.keys(data).length > 0, "You must provide at least one field to update")
 
 const queryFlagsCore = {
   _seller: z.preprocess(val => String(val).toLowerCase() === "true", z.boolean()).optional(),

--- a/apps/v2/src/modules/social/posts/__tests__/updatePost.test.ts
+++ b/apps/v2/src/modules/social/posts/__tests__/updatePost.test.ts
@@ -126,6 +126,32 @@ describe("[PUT] /social/posts/:id", () => {
     ])
   })
 
+  it("should throw zod error if attempting to update with an empty title", async () => {
+    const response = await server.inject({
+      url: `/social/posts/${POST_ID}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        title: ""
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toStrictEqual([
+      {
+        code: "too_small",
+        message: "Title cannot be empty",
+        path: ["title"]
+      }
+    ])
+  })
+
   it("should throw 401 error when attempting to create without API key", async () => {
     const response = await server.inject({
       url: `/social/posts/${POST_ID}`,

--- a/apps/v2/src/modules/social/posts/posts.schema.ts
+++ b/apps/v2/src/modules/social/posts/posts.schema.ts
@@ -3,6 +3,13 @@ import { z } from "zod"
 
 import { mediaPropertiesWithErrors, profileCore } from "../../auth/auth.schema"
 
+const POST_TITLE_MIN_LENGTH = 1
+const POST_TITLE_MAX_LENGTH = 280
+const POST_BODY_MAX_LENGTH = 280
+const POST_TAGS_MAX_LENGTH = 24
+const POST_MAX_TAGS = 8
+const COMMENT_BODY_MAX_LENGTH = 280
+
 const mediaCore = {
   media: z.object(mediaPropertiesWithErrors).nullish()
 }
@@ -14,9 +21,9 @@ const tagsAndMedia = {
     .string({
       invalid_type_error: "Tags must be an array of strings"
     })
-    .max(24, "Tags cannot be greater than 24 characters")
+    .max(POST_TAGS_MAX_LENGTH, "Tags cannot be greater than 24 characters")
     .array()
-    .max(8, "You cannot have more than 8 tags")
+    .max(POST_MAX_TAGS, "You cannot have more than 8 tags")
     .optional(),
   ...mediaCore
 }
@@ -27,14 +34,14 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
-    .min(1, "Title cannot be empty")
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(280, "Body cannot be greater than 280 characters")
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -45,14 +52,15 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
-    .max(280, "Title cannot be greater than 280 characters")
+    .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
     .trim()
     .nullish(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(280, "Body cannot be greater than 280 characters")
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -125,7 +133,7 @@ const commentCore = {
       invalid_type_error: "Body must be a string",
       required_error: "Body is required"
     })
-    .max(280, "Body cannot be greater than 280 characters")
+    .max(COMMENT_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim(),
   replyToId: z
     .number({
@@ -161,10 +169,7 @@ export const createPostBaseSchema = z.object(postCore)
 
 export const updatePostBodySchema = z
   .object(updatePostCore)
-  .refine(
-    ({ title, body, tags, media }) => !!title || !!body || !!tags || !!media,
-    "You must provide either title, body, tags, or media"
-  )
+  .refine(data => Object.keys(data).length > 0, "You must provide at least one field to update")
 
 export const createPostSchema = z.object({
   ...postOwner,


### PR DESCRIPTION
- Adds `.min(1)` to update schemas.
- Extracts length values to constants.
  - In the future these will be moved to a separate constants file for all modules.