### PR TITLE
Remove content-type header if PUT and no body for social follow/unfollow

### DIFF
--- a/apps/v1/src/hooks/onRequest.ts
+++ b/apps/v1/src/hooks/onRequest.ts
@@ -1,0 +1,23 @@
+import fp from "fastify-plugin"
+
+// Uses glob pattern
+const TARGET_ENDPOINTS = ["/api/v1/social/profiles/*/follow", "/api/v1/social/profiles/*/unfollow"]
+const TARGET_METHODS = ["PUT"]
+
+export default fp(async fastify => {
+  fastify.addHook("onRequest", (req, reply, next) => {
+    const contentType = req.headers["content-type"]
+    const { method, url } = req
+
+    // Convert glob pattern to regex pattern
+    const patterns = TARGET_ENDPOINTS.map(pattern => new RegExp("^" + pattern.replace(/\*/g, "[^/]+") + "$"))
+    const shouldRemoveHeader = patterns.some(pattern => pattern.test(url))
+    const isTargetMethod = TARGET_METHODS.includes(method)
+
+    if (contentType?.includes("application/json") && shouldRemoveHeader && isTargetMethod) {
+      delete req.headers["content-type"]
+    }
+
+    return next()
+  })
+})

--- a/apps/v2/src/hooks/onRequest.ts
+++ b/apps/v2/src/hooks/onRequest.ts
@@ -2,6 +2,7 @@ import fp from "fastify-plugin"
 
 // Uses glob pattern
 const TARGET_ENDPOINTS = ["/social/profiles/*/follow", "/social/profiles/*/unfollow"]
+const TARGET_METHODS = ["PUT"]
 
 export default fp(async fastify => {
   fastify.addHook("onRequest", (req, reply, next) => {
@@ -11,8 +12,9 @@ export default fp(async fastify => {
     // Convert glob pattern to regex pattern
     const patterns = TARGET_ENDPOINTS.map(pattern => new RegExp("^" + pattern.replace(/\*/g, "[^/]+") + "$"))
     const shouldRemoveHeader = patterns.some(pattern => pattern.test(url))
+    const isTargetMethod = TARGET_METHODS.includes(method)
 
-    if (method === "PUT" && contentType?.includes("application/json") && shouldRemoveHeader) {
+    if (contentType?.includes("application/json") && shouldRemoveHeader && isTargetMethod) {
       delete req.headers["content-type"]
     }
 

--- a/apps/v2/src/hooks/onRequest.ts
+++ b/apps/v2/src/hooks/onRequest.ts
@@ -1,0 +1,21 @@
+import fp from "fastify-plugin"
+
+// Uses glob pattern
+const TARGET_ENDPOINTS = ["/social/profiles/*/follow", "/social/profiles/*/unfollow"]
+
+export default fp(async fastify => {
+  fastify.addHook("onRequest", (req, reply, next) => {
+    const contentType = req.headers["content-type"]
+    const { method, url } = req
+
+    // Convert glob pattern to regex pattern
+    const patterns = TARGET_ENDPOINTS.map(pattern => new RegExp("^" + pattern.replace(/\*/g, "[^/]+") + "$"))
+    const shouldRemoveHeader = patterns.some(pattern => pattern.test(url))
+
+    if (method === "PUT" && contentType?.includes("application/json") && shouldRemoveHeader) {
+      delete req.headers["content-type"]
+    }
+
+    return next()
+  })
+})

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -4,7 +4,7 @@ services:
   prometheus:
     image: prom/prometheus
     container_name: prometheus
-    restart: no
+    restart: "no"
     ports:
       - 9090:9090
     volumes:
@@ -18,7 +18,7 @@ services:
   grafana:
     image: grafana/grafana
     container_name: grafana
-    restart: no
+    restart: "no"
     ports:
       - 9091:3000
     environment:
@@ -36,7 +36,7 @@ services:
   loki:
     image: grafana/loki
     container_name: loki
-    restart: no
+    restart: "no"
     ports:
       - 3100:3100
     command: -config.file=/etc/loki/local-config.yaml
@@ -48,7 +48,7 @@ services:
   postgres:
     image: postgres:16
     container_name: api-db
-    restart: no
+    restart: "no"
     environment:
       POSTGRES_USER: ${DC_POSTGRES_USER}
       POSTGRES_PASSWORD: ${DC_POSTGRES_PASSWORD}
@@ -68,7 +68,7 @@ services:
 
   api-v1:
     container_name: api-v1
-    restart: no
+    restart: "no"
     build:
       context: .
       dockerfile: ./apps/v1/Dockerfile
@@ -86,7 +86,7 @@ services:
 
   api-v2:
     container_name: api-v2
-    restart: no
+    restart: "no"
     build:
       context: .
       dockerfile: ./apps/v2/Dockerfile
@@ -104,7 +104,7 @@ services:
 
   docs:
     container_name: docs
-    restart: no
+    restart: "no"
     build:
       context: .
       dockerfile: ./apps/docs/Dockerfile


### PR DESCRIPTION
Finally fixing this. The social follow/unfollow has no request body, and students are receiving a generic "something went wrong" error. We could return a more friendly error but I'd rather just allow these requests if the header was provided.

I've set up the onRequest hook to be extendable for both the method and route being targeted.

This fixes this error for both v1 and v2.

Also fixed some syntax errors in docker-compose.