### PR TITLE
JWT signing, venueManager boolean, schema updates

### DIFF
--- a/apps/v2/src/modules/auth/auth.controller.ts
+++ b/apps/v2/src/modules/auth/auth.controller.ts
@@ -63,9 +63,6 @@ export async function loginHandler(
     throw new Unauthorized("Invalid email or password")
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { password, salt, ...rest } = profile.data
-
   return {
     data: {
       name: profile.data.name,
@@ -73,7 +70,10 @@ export async function loginHandler(
       bio: profile.data.bio,
       avatar: profile.data.avatar,
       banner: profile.data.banner,
-      accessToken: request.jwt.sign(rest)
+      accessToken: request.jwt.sign({
+        name: profile.data.name,
+        email: profile.data.email
+      })
     }
   }
 }

--- a/apps/v2/src/modules/auth/auth.schema.ts
+++ b/apps/v2/src/modules/auth/auth.schema.ts
@@ -1,5 +1,9 @@
 import { z } from "zod"
 
+const venueManager = {
+  venueManager: z.boolean({ invalid_type_error: "Venue manager must be a boolean" }).optional()
+}
+
 export const mediaProperties = {
   url: z.string().url(),
   alt: z.string().optional().default("")
@@ -11,6 +15,7 @@ export const mediaPropertiesWithErrors = {
       required_error: "Image URL is required",
       invalid_type_error: "Image URL must be a string"
     })
+    .max(300, "Image URL cannot be greater than 300 characters")
     .url("Image URL must be valid URL"),
   alt: z
     .string({
@@ -75,6 +80,7 @@ export const profileCore = {
 
 export const createProfileBodySchema = z.object({
   ...profileCore,
+  ...venueManager,
   password: z
     .string({
       required_error: "Password is required",
@@ -83,7 +89,7 @@ export const createProfileBodySchema = z.object({
     .min(8, "Password must be at least 8 characters")
 })
 
-export const createProfileResponseSchema = z.object(profileCore)
+export const createProfileResponseSchema = z.object(profileCore).extend(venueManager)
 
 export const profileMediaSchema = z.object(profileMedia)
 

--- a/apps/v2/src/modules/auth/auth.service.ts
+++ b/apps/v2/src/modules/auth/auth.service.ts
@@ -27,9 +27,13 @@ export async function createProfile(input: CreateProfileInput) {
       salt,
       password: hash
     },
-    include: {
+    select: {
+      name: true,
+      email: true,
+      bio: true,
       avatar: true,
-      banner: true
+      banner: true,
+      venueManager: !!rest.venueManager
     }
   })
 

--- a/apps/v2/src/modules/holidaze/bookings/bookings.schema.ts
+++ b/apps/v2/src/modules/holidaze/bookings/bookings.schema.ts
@@ -50,7 +50,8 @@ export const createBookingSchema = z.object({
       invalid_type_error: "Guests must be a number"
     })
     .int("Guests must be an integer")
-    .min(1, "Guests must be at least 1"),
+    .min(1, "Guests must be at least 1")
+    .max(100, "Guests cannot exceed 100"),
   venueId: z
     .string({
       required_error: "venueId is required",

--- a/apps/v2/src/modules/holidaze/venues/__tests__/createVenue.test.ts
+++ b/apps/v2/src/modules/holidaze/venues/__tests__/createVenue.test.ts
@@ -133,6 +133,33 @@ describe("[POST] /holidaze/venues", () => {
     ])
   })
 
+  it("should throw zod error if price is greater than 10,000", async () => {
+    const response = await server.inject({
+      url: "/holidaze/venues",
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        ...createData,
+        price: 10_001
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toStrictEqual([
+      {
+        code: "too_big",
+        message: "Price cannot be greater than 10,000",
+        path: ["price"]
+      }
+    ])
+  })
+
   it("should throw 401 error when attempting to create without API key", async () => {
     const response = await server.inject({
       url: "/holidaze/venues",

--- a/apps/v2/src/modules/holidaze/venues/__tests__/updateVenue.test.ts
+++ b/apps/v2/src/modules/holidaze/venues/__tests__/updateVenue.test.ts
@@ -134,6 +134,38 @@ describe("[PUT] /holidaze/venues/:id", () => {
     })
   })
 
+  it("should throw zod error if price is greater than 10,000", async () => {
+    // Make user a venue manager
+    await db.userProfile.update({
+      where: { name: USER_NAME },
+      data: { venueManager: true }
+    })
+
+    const response = await server.inject({
+      url: `/holidaze/venues/${VENUE_ID}`,
+      method: "PUT",
+      headers: {
+        Authorization: `Bearer ${BEARER_TOKEN}`,
+        "X-Noroff-API-Key": API_KEY
+      },
+      payload: {
+        price: 10_001
+      }
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toEqual(400)
+    expect(res.data).not.toBeDefined()
+    expect(res.meta).not.toBeDefined()
+    expect(res.errors).toStrictEqual([
+      {
+        code: "too_big",
+        message: "Price cannot be greater than 10,000",
+        path: ["price"]
+      }
+    ])
+  })
+
   it("should throw zod errors if no data was provided", async () => {
     const response = await server.inject({
       url: `/holidaze/venues/${VENUE_ID}`,

--- a/apps/v2/src/modules/holidaze/venues/venues.schema.ts
+++ b/apps/v2/src/modules/holidaze/venues/venues.schema.ts
@@ -39,8 +39,16 @@ const venueLocationWithErrors = {
   zip: z.string({ invalid_type_error: "Zip must be a string" }).nullish(),
   country: z.string({ invalid_type_error: "Country must be a string" }).nullish(),
   continent: z.string({ invalid_type_error: "Continent must be a string" }).nullish(),
-  lat: z.number({ invalid_type_error: "Latitude must be a number" }).nullish(),
-  lng: z.number({ invalid_type_error: "Longitude must be a number" }).nullish()
+  lat: z
+    .number({ invalid_type_error: "Latitude must be a number" })
+    .min(-90, "Latitude must be between -90 and 90")
+    .max(90, "Latitude must be between -90 and 90")
+    .nullish(),
+  lng: z
+    .number({ invalid_type_error: "Longitude must be a number" })
+    .min(-180, "Longitude must be between -180 and 180")
+    .max(180, "Longitude must be between -180 and 180")
+    .nullish()
 }
 
 export const venueCore = {
@@ -101,7 +109,8 @@ export const createVenueSchema = z.object({
       invalid_type_error: "Price must be a number",
       required_error: "Price is required"
     })
-    .min(0, "You cannot pay guests to stay at your venue"),
+    .min(0, "You cannot pay guests to stay at your venue")
+    .max(10_000, "Price cannot be greater than 10,000"),
   maxGuests: z
     .number({
       invalid_type_error: "Max guests must be a number",
@@ -138,6 +147,7 @@ const updateVenueCore = {
       invalid_type_error: "Price must be a number"
     })
     .min(0, "You cannot pay guests to stay at your venue")
+    .max(10_000, "Price cannot be greater than 10,000")
     .optional(),
   maxGuests: z
     .number({


### PR DESCRIPTION
- Only sign JWT with name and email.
- Allow specifying `venueManager` when creating an account.
- Adds max length to URLs of 300 characters.
- Merges in changes from #171 and adds on to it

Closes #170 