### PR TITLE
blog: remove auth guard from viewing posts

### DIFF
--- a/apps/v2/src/modules/blog/posts/__tests__/getPost.test.ts
+++ b/apps/v2/src/modules/blog/posts/__tests__/getPost.test.ts
@@ -5,19 +5,15 @@ import { db } from "@/utils"
 const POST_ID = "7ebb7a88-0cb5-4a12-8d68-defe899eae54"
 const SECOND_POST_ID = "4261637c-29b5-41d6-8d87-fd21d58400a0"
 let USER_NAME = ""
-let SECOND_USER_NAME = ""
-let BEARER_TOKEN = ""
 
 beforeEach(async () => {
-  const { name, bearerToken } = await getAuthCredentials()
+  const { name } = await getAuthCredentials()
   const { name: secondName } = await getAuthCredentials({
     name: "test_user_two",
     email: "test_user_two@noroff.no"
   })
 
   USER_NAME = name
-  SECOND_USER_NAME = secondName
-  BEARER_TOKEN = bearerToken
 
   await db.blogPost.create({
     data: {
@@ -51,10 +47,7 @@ describe("[GET] /blog/posts/:name/:id", () => {
   it("should return single post based on id", async () => {
     const response = await server.inject({
       url: `/blog/posts/${USER_NAME}/${POST_ID}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
+      method: "GET"
     })
     const res = await response.json()
 
@@ -85,33 +78,10 @@ describe("[GET] /blog/posts/:name/:id", () => {
     expect(res.meta).toStrictEqual({})
   })
 
-  it("should return 403 if user does not have permission to view post", async () => {
-    const response = await server.inject({
-      url: `/blog/posts/${SECOND_USER_NAME}/${SECOND_POST_ID}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
-    })
-    const res = await response.json()
-
-    expect(response.statusCode).toBe(403)
-    expect(res.data).not.toBeDefined()
-    expect(res.meta).not.toBeDefined()
-    expect(res.errors).toBeDefined()
-    expect(res.errors).toHaveLength(1)
-    expect(res.errors[0]).toStrictEqual({
-      message: "You do not have permission to view this post"
-    })
-  })
-
   it("should return 404 if user requests a post from another user", async () => {
     const response = await server.inject({
       url: `/blog/posts/${USER_NAME}/${SECOND_POST_ID}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
+      method: "GET"
     })
     const res = await response.json()
 
@@ -129,10 +99,7 @@ describe("[GET] /blog/posts/:name/:id", () => {
   it("should return 404 if post not found", async () => {
     const response = await server.inject({
       url: `/blog/posts/${USER_NAME}/deec56b3-533e-4bbf-bc0d-4b4bc8af3e30`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
+      method: "GET"
     })
     const res = await response.json()
 

--- a/apps/v2/src/modules/blog/posts/__tests__/getPosts.test.ts
+++ b/apps/v2/src/modules/blog/posts/__tests__/getPosts.test.ts
@@ -3,19 +3,11 @@ import { getAuthCredentials, server } from "@/test-utils"
 import { db } from "@/utils"
 
 let USER_NAME = ""
-let SECOND_USER_NAME = ""
-let BEARER_TOKEN = ""
 
 beforeEach(async () => {
-  const { name, bearerToken } = await getAuthCredentials()
-  const { name: secondName } = await getAuthCredentials({
-    name: "test_user_two",
-    email: "test_user_two@noroff.no"
-  })
+  const { name } = await getAuthCredentials()
 
   USER_NAME = name
-  SECOND_USER_NAME = secondName
-  BEARER_TOKEN = bearerToken
 
   await db.blogPost.createMany({
     data: [
@@ -30,13 +22,6 @@ beforeEach(async () => {
         owner: name
       }
     ]
-  })
-
-  await db.blogPost.create({
-    data: {
-      title: "Second user post",
-      owner: secondName
-    }
   })
 })
 
@@ -53,10 +38,7 @@ describe("[GET] /blog/posts/:name", () => {
   it("should return all posts", async () => {
     const response = await server.inject({
       url: `/blog/posts/${USER_NAME}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
+      method: "GET"
     })
     const res = await response.json()
 
@@ -79,10 +61,7 @@ describe("[GET] /blog/posts/:name", () => {
   it("should return all posts with pagination and sort", async () => {
     const response = await server.inject({
       url: `/blog/posts/${USER_NAME}?page=1&limit=1&sort=title&sortOrder=asc`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
+      method: "GET"
     })
     const res = await response.json()
 
@@ -105,10 +84,7 @@ describe("[GET] /blog/posts/:name", () => {
   it("should return all posts that match a tag", async () => {
     const response = await server.inject({
       url: `/blog/posts/${USER_NAME}?_tag=tag1`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
+      method: "GET"
     })
     const res = await response.json()
 
@@ -125,26 +101,6 @@ describe("[GET] /blog/posts/:name", () => {
       nextPage: null,
       pageCount: 1,
       totalCount: 1
-    })
-  })
-
-  it("should return 403 if user does not have permission to view post", async () => {
-    const response = await server.inject({
-      url: `/blog/posts/${SECOND_USER_NAME}`,
-      method: "GET",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`
-      }
-    })
-    const res = await response.json()
-
-    expect(response.statusCode).toBe(403)
-    expect(res.data).not.toBeDefined()
-    expect(res.meta).not.toBeDefined()
-    expect(res.errors).toBeDefined()
-    expect(res.errors).toHaveLength(1)
-    expect(res.errors[0]).toStrictEqual({
-      message: "You do not have permission to view this post"
     })
   })
 })

--- a/apps/v2/src/modules/blog/posts/posts.controller.ts
+++ b/apps/v2/src/modules/blog/posts/posts.controller.ts
@@ -24,14 +24,9 @@ export async function getPostsHandler(
     }
   }>
 ) {
-  const { name: paramsName } = await profileNameSchema.parseAsync(request.params)
+  const { name } = await profileNameSchema.parseAsync(request.params)
   await postsQuerySchema.parseAsync(request.query)
   const { sort, sortOrder, limit, page, _tag } = request.query
-  const { name } = request.user as UserProfile
-
-  if (name.toLowerCase() !== paramsName.toLowerCase()) {
-    throw new Forbidden("You do not have permission to view this post")
-  }
 
   if (limit && limit > 100) {
     throw new BadRequest("Limit cannot be greater than 100")
@@ -50,12 +45,7 @@ export async function getPostHandler(
     }
   }>
 ) {
-  const { id, name: paramsName } = await postIdWithNameParamsSchema.parseAsync(request.params)
-  const { name } = request.user as UserProfile
-
-  if (name.toLowerCase() !== paramsName.toLowerCase()) {
-    throw new Forbidden("You do not have permission to view this post")
-  }
+  const { id, name } = await postIdWithNameParamsSchema.parseAsync(request.params)
 
   const post = await getPost(id, name)
 

--- a/apps/v2/src/modules/blog/posts/posts.route.ts
+++ b/apps/v2/src/modules/blog/posts/posts.route.ts
@@ -21,10 +21,8 @@ async function postsRoutes(server: FastifyInstance) {
   server.get(
     "/:name",
     {
-      onRequest: [server.authenticate],
       schema: {
         tags: ["blog-posts"],
-        security: [{ bearerAuth: [] }],
         params: profileNameSchema,
         querystring: postsQuerySchema,
         response: {
@@ -85,10 +83,8 @@ async function postsRoutes(server: FastifyInstance) {
   server.get(
     "/:name/:id",
     {
-      onRequest: [server.authenticate],
       schema: {
         tags: ["blog-posts"],
-        security: [{ bearerAuth: [] }],
         params: postIdWithNameParamsSchema,
         response: {
           200: createResponseSchema(displayPostSchema)


### PR DESCRIPTION
- removes auth guard from `GET /:name` and `GET /:name/:id`
- updates tests to match