### PR TITLE
fix/blog: body max length, docs callout

### DIFF
--- a/apps/docs/content/docs/v2/blog/posts.mdx
+++ b/apps/docs/content/docs/v2/blog/posts.mdx
@@ -6,6 +6,10 @@ description: Posts related to Blog
 <Callout variant="warning">
   Some of these are authenticated endpoints. You can visit [authentication](../auth/register) to register an account.
 </Callout>
+<Callout variant="warning">
+  An API key is not required to access the authenticated endpoints, but you will still need to provide a valid access
+  token.
+</Callout>
 
 These endpoints allow you to create, read, update and delete posts. Posts are the main content of a blog and can be created by any profile.
 

--- a/apps/v2/src/modules/blog/posts/posts.schema.ts
+++ b/apps/v2/src/modules/blog/posts/posts.schema.ts
@@ -5,7 +5,7 @@ import { mediaPropertiesWithErrors, profileCore } from "../../auth/auth.schema"
 
 const POST_TITLE_MIN_LENGTH = 1
 const POST_TITLE_MAX_LENGTH = 280
-const POST_BODY_MAX_LENGTH = 280
+const POST_BODY_MAX_LENGTH = 2000
 const POST_TAGS_MAX_LENGTH = 24
 const POST_MAX_TAGS = 8
 
@@ -51,7 +51,7 @@ export const postCore = {
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 2000 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia
@@ -70,7 +70,7 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 2000 characters")
     .trim()
     .nullish(),
   ...tagsAndMedia


### PR DESCRIPTION
- Ups body max length to 2000 characters from 200.
- Adds another Callout in blog docs explaining API Key is not required.