### PR TITLE
feat/login: Add optional params to login

### DIFF
--- a/apps/docs/content/docs/v2/auth/login.mdx
+++ b/apps/docs/content/docs/v2/auth/login.mdx
@@ -3,6 +3,42 @@ title: Login
 description: Login a user
 ---
 
+## Query parameters
+
+Not all of the properties of a user are returned by default. You can use the following optional query parameters to include additional properties in the response.
+
+<TypeTable
+  type={{
+    _holidaze: {
+      type: "boolean",
+      default: "false",
+      description: "Include more information about the user related to Holidaze endpoints. E.g venueManager boolean."
+    }
+  }}
+/>
+
+```json title="Example with all optional query parameters"
+{
+  "data": {
+    "name": "my_username",
+    "email": "first.last@stud.noroff.no",
+    "avatar": {
+      "url": "https://img.service.com/avatar.jpg",
+      "alt": "My avatar alt text"
+    },
+    "banner": {
+      "url": "https://img.service.com/banner.jpg",
+      "alt": "My banner alt text"
+    },
+    "accessToken": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9....",
+    "venueManager": true
+  },
+  "meta": {}
+}
+```
+
+<Hr />
+
 ## Login a user
 
 <EndpointDetails method="POST" path="/auth/login" />

--- a/apps/v2/src/modules/auth/__tests__/login.test.ts
+++ b/apps/v2/src/modules/auth/__tests__/login.test.ts
@@ -42,7 +42,29 @@ describe("[POST] /auth/login", () => {
     expect(res.data.name).toBe(TEST_USER_NAME)
     expect(res.data.email).toBe(TEST_USER_EMAIL)
     expect(res.data.bio).toBe(null)
+    expect(res.data.venueManager).not.toBeDefined()
     expect(res.data).not.toHaveProperty(TEST_USER_PASSWORD)
+    expect(res.meta).toBeDefined()
+    expect(res.meta).toStrictEqual({})
+  })
+
+  it("should include optional fields when providing query params", async () => {
+    const response = await server.inject({
+      url: "/auth/login?_holidaze=true",
+      method: "POST",
+      payload: {
+        email: TEST_USER_EMAIL,
+        password: TEST_USER_PASSWORD
+      }
+    })
+
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toBeDefined()
+    expect(res.data).toHaveProperty("venueManager")
+    expect(res.data.venueManager).toBeDefined()
+    expect(res.data.venueManager).toBe(false)
     expect(res.meta).toBeDefined()
     expect(res.meta).toStrictEqual({})
   })

--- a/apps/v2/src/modules/auth/auth.route.ts
+++ b/apps/v2/src/modules/auth/auth.route.ts
@@ -8,6 +8,7 @@ import {
   createProfileBodySchema,
   createProfileResponseSchema,
   loginBodySchema,
+  loginQuerySchema,
   loginResponseSchema
 } from "./auth.schema"
 
@@ -32,6 +33,7 @@ async function authRoutes(server: FastifyInstance) {
       schema: {
         tags: ["auth"],
         body: loginBodySchema,
+        querystring: loginQuerySchema,
         response: {
           200: createResponseSchema(loginResponseSchema)
         }

--- a/apps/v2/src/modules/auth/auth.schema.ts
+++ b/apps/v2/src/modules/auth/auth.schema.ts
@@ -45,7 +45,8 @@ export const loginResponseSchema = z.object({
   bio: z.string().nullish(),
   avatar: z.object(mediaProperties).optional(),
   banner: z.object(mediaProperties).optional(),
-  accessToken: z.string()
+  accessToken: z.string(),
+  ...venueManager
 })
 
 export const profileMedia = {
@@ -107,6 +108,12 @@ export const createApiKeyResponseSchema = z.object({
   status: z.string(),
   key: z.string().uuid()
 })
+
+const queryFlagsCore = {
+  _holidaze: z.preprocess(val => String(val).toLowerCase() === "true", z.boolean()).optional()
+}
+
+export const loginQuerySchema = z.object(queryFlagsCore)
 
 export type LoginInput = z.infer<typeof loginBodySchema>
 export type CreateProfileInput = z.infer<typeof createProfileBodySchema>

--- a/apps/v2/src/modules/auth/auth.service.ts
+++ b/apps/v2/src/modules/auth/auth.service.ts
@@ -2,6 +2,7 @@ import { hashPassword } from "@noroff/api-utils"
 
 import { db } from "@/utils"
 
+import { AuthLoginIncludes } from "./auth.controller"
 import { CreateProfileInput } from "./auth.schema"
 
 const DEFAULT_AVATAR = {
@@ -40,10 +41,21 @@ export async function createProfile(input: CreateProfileInput) {
   return { data: profile }
 }
 
-export async function findProfileByEmail(email: string) {
+export async function findProfileByEmail(email: string, includes: AuthLoginIncludes = {}) {
+  const includeHolidaze = includes.holidaze ? { venueManager: true } : {}
+
   const data = await db.userProfile.findUnique({
     where: { email },
-    include: { avatar: true, banner: true }
+    select: {
+      ...includeHolidaze,
+      name: true,
+      email: true,
+      bio: true,
+      avatar: true,
+      banner: true,
+      salt: true,
+      password: true
+    }
   })
 
   return { data }


### PR DESCRIPTION
- adds `_holidaze` optional query param to `POST /auth/login`. Returns the `venueManager` boolean if included.
  - also adds test
- adds section for query params to login docs.

This also serves as a setup and gives us the ability to extend this to add similar optional params like `_social` and `_auctionhouse` in the future should we want/need to return more info on login.