### PR TITLE
listings: early return if listing doesn't exist

### DIFF
--- a/apps/v2/src/modules/auction/listings/listing.utils.ts
+++ b/apps/v2/src/modules/auction/listings/listing.utils.ts
@@ -35,7 +35,13 @@ export async function scheduleCreditsTransfer(listingId: string, endsAt: Date): 
     // Get listing
     const listing = (await getListing(listingId, { bids: true })) as ListingWithBids
 
-    if (listing && listing.data.bids.length > 0) {
+    // If listing does not exist, return.
+    // This happens when the listing is deleted before the job runs.
+    if (!listing?.data) {
+      return
+    }
+
+    if (listing.data?.bids?.length > 0) {
       // Get highest bid of listing
       const [winner, ...losers] = listing.data.bids.sort((a, b) => b.amount - a.amount)
 


### PR DESCRIPTION
since we don't keep track of or store the id that node-scheduler gives back, we cannot remove/cancel a schedule. i think just returning early if the listing doesn't exist is fine.

closes #178 