### PR TITLE
trim before checking length of input

### DIFF
--- a/apps/v1/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v1/src/modules/auction/listings/listings.schema.ts
@@ -73,15 +73,15 @@ export const createListingSchema = z.object({
       required_error: "Title is required",
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
-    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim(),
+    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters"),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .nullish(),
   endsAt: z
     .preprocess(
@@ -112,16 +112,16 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
     .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim()
     .nullish(),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .nullish(),
   ...tagsAndMedia
 }

--- a/apps/v1/src/modules/auction/profiles/profiles.schema.ts
+++ b/apps/v1/src/modules/auction/profiles/profiles.schema.ts
@@ -26,8 +26,8 @@ export const profileCore = {
   name: z
     .string()
     .regex(/^[\w]+$/, "Name can only use a-Z, 0-9, and _")
-    .max(20, "Name cannot be greater than 20 characters")
-    .trim(),
+    .trim()
+    .max(20, "Name cannot be greater than 20 characters"),
   email: z
     .string({
       invalid_type_error: "Email must be a string"

--- a/apps/v1/src/modules/holidaze/profiles/profiles.schema.ts
+++ b/apps/v1/src/modules/holidaze/profiles/profiles.schema.ts
@@ -35,8 +35,8 @@ export const profileCore = {
   name: z
     .string()
     .regex(/^[\w]+$/, "Name can only use a-Z, 0-9, and _")
-    .max(20, "Name cannot be greater than 20 characters")
-    .trim(),
+    .trim()
+    .max(20, "Name cannot be greater than 20 characters"),
   email: z
     .string({
       invalid_type_error: "Email must be a string"

--- a/apps/v1/src/modules/social/posts/posts.schema.ts
+++ b/apps/v1/src/modules/social/posts/posts.schema.ts
@@ -33,15 +33,15 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
+    .trim()
     .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
-    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim(),
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters"),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .nullish(),
   ...tagsAndMedia
 }
@@ -51,16 +51,16 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
     .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim()
     .nullish(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .nullish(),
   ...tagsAndMedia
 }
@@ -121,8 +121,8 @@ const commentCore = {
       invalid_type_error: "Body must be a string",
       required_error: "Body is required"
     })
-    .max(COMMENT_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
-    .trim(),
+    .trim()
+    .max(COMMENT_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters"),
   replyToId: z
     .number({
       invalid_type_error: "ReplyToId must be a number"

--- a/apps/v1/src/modules/social/profiles/profiles.schema.ts
+++ b/apps/v1/src/modules/social/profiles/profiles.schema.ts
@@ -25,8 +25,8 @@ export const profileCore = {
   name: z
     .string()
     .regex(/^[\w]+$/, "Name can only use a-Z, 0-9, and _")
-    .max(20, "Name cannot be greater than 20 characters")
-    .trim(),
+    .trim()
+    .max(20, "Name cannot be greater than 20 characters"),
   email: z
     .string({
       invalid_type_error: "Email must be a string"

--- a/apps/v2/src/modules/auction/listings/listings.schema.ts
+++ b/apps/v2/src/modules/auction/listings/listings.schema.ts
@@ -66,15 +66,15 @@ export const createListingSchema = z.object({
       required_error: "Title is required",
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
-    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim(),
+    .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters"),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .nullish(),
   endsAt: z
     .preprocess(
@@ -105,16 +105,16 @@ export const updateListingCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(LISTING_TITLE_MIN_LENGTH, "Title cannot be empty")
     .max(LISTING_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim()
     .nullish(),
   description: z
     .string({
       invalid_type_error: "Description must be a string"
     })
-    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .trim()
+    .max(LISTING_DESCRIPTION_MAX_LENGTH, "Description cannot be greater than 280 characters")
     .nullish(),
   ...tagsAndMedia
 }

--- a/apps/v2/src/modules/auth/auth.schema.ts
+++ b/apps/v2/src/modules/auth/auth.schema.ts
@@ -55,7 +55,7 @@ export const profileMedia = {
 }
 
 export const profileBio = {
-  bio: z.string().max(160, "Bio cannot be greater than 160 characters").trim().nullish()
+  bio: z.string().trim().max(160, "Bio cannot be greater than 160 characters").nullish()
 }
 
 export const profileCore = {
@@ -65,8 +65,8 @@ export const profileCore = {
       invalid_type_error: "Name must be a string"
     })
     .regex(/^[\w]+$/, "Name can only use a-Z, 0-9, and _")
-    .max(20, "Name cannot be greater than 20 characters")
-    .trim(),
+    .trim()
+    .max(20, "Name cannot be greater than 20 characters"),
   email: z
     .string({
       required_error: "Email is required",
@@ -75,7 +75,7 @@ export const profileCore = {
     .email()
     .regex(/^[\w\-.]+@(stud\.)?noroff\.no$/, "Only stud.noroff.no emails are allowed to register")
     .trim(),
-  bio: z.string().max(160, "Bio cannot be greater than 160 characters").trim().nullish(),
+  bio: z.string().trim().max(160, "Bio cannot be greater than 160 characters").nullish(),
   ...profileMedia
 }
 

--- a/apps/v2/src/modules/blog/posts/posts.schema.ts
+++ b/apps/v2/src/modules/blog/posts/posts.schema.ts
@@ -44,15 +44,15 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
+    .trim()
     .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
-    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim(),
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters"),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, `Body cannot be greater than ${POST_BODY_MAX_LENGTH} characters`)
     .trim()
+    .max(POST_BODY_MAX_LENGTH, `Body cannot be greater than ${POST_BODY_MAX_LENGTH} characters`)
     .nullish(),
   ...tagsAndMedia
 }
@@ -62,16 +62,16 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
     .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim()
     .nullish(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, `Body cannot be greater than ${POST_BODY_MAX_LENGTH} characters`)
     .trim()
+    .max(POST_BODY_MAX_LENGTH, `Body cannot be greater than ${POST_BODY_MAX_LENGTH} characters`)
     .nullish(),
   ...tagsAndMedia
 }

--- a/apps/v2/src/modules/social/posts/posts.schema.ts
+++ b/apps/v2/src/modules/social/posts/posts.schema.ts
@@ -34,15 +34,15 @@ export const postCore = {
       invalid_type_error: "Title must be a string",
       required_error: "Title is required"
     })
+    .trim()
     .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
-    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim(),
+    .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters"),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .nullish(),
   ...tagsAndMedia
 }
@@ -52,16 +52,16 @@ const updatePostCore = {
     .string({
       invalid_type_error: "Title must be a string"
     })
+    .trim()
     .min(POST_TITLE_MIN_LENGTH, "Title cannot be empty")
     .max(POST_TITLE_MAX_LENGTH, "Title cannot be greater than 280 characters")
-    .trim()
     .nullish(),
   body: z
     .string({
       invalid_type_error: "Body must be a string"
     })
-    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .trim()
+    .max(POST_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
     .nullish(),
   ...tagsAndMedia
 }
@@ -133,8 +133,8 @@ const commentCore = {
       invalid_type_error: "Body must be a string",
       required_error: "Body is required"
     })
-    .max(COMMENT_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters")
-    .trim(),
+    .trim()
+    .max(COMMENT_BODY_MAX_LENGTH, "Body cannot be greater than 280 characters"),
   replyToId: z
     .number({
       invalid_type_error: "ReplyToId must be a number"


### PR DESCRIPTION
with the old setup you could provide a string of `" "` and it would pass validation, because we are checking the length before we trim whitespaces. Submitting only `" "` would then become `""` before inserting to db (and be invalid according to the schema,) thus causing errors when validating the response.