### PR TITLE
fix/pnpm-prisma

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,5 +135,5 @@ dist
 # Turborepo
 .turbo
 
-# Contentlayer
-.contentlayer
+# Prisma client
+**/prisma/generated

--- a/apps/v1/prisma/schema.prisma
+++ b/apps/v1/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../node_modules/@prisma/v1-client"
+  output   = "../prisma/generated/v1-client"
 }
 
 datasource db {

--- a/apps/v1/prisma/schema.prisma
+++ b/apps/v1/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../prisma/generated/v1-client"
+  output   = "./generated/v1-client"
 }
 
 datasource db {

--- a/apps/v1/src/modules/auction/listings/listings.controller.ts
+++ b/apps/v1/src/modules/auction/listings/listings.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { AuctionBid, AuctionListing, AuctionProfile, Prisma } from "@prisma/v1-client"
+import { AuctionBid, AuctionListing, AuctionProfile, Prisma } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { getProfile } from "../profiles/profiles.service"

--- a/apps/v1/src/modules/auction/listings/listings.service.ts
+++ b/apps/v1/src/modules/auction/listings/listings.service.ts
@@ -1,4 +1,4 @@
-import { AuctionListing } from "@prisma/v1-client"
+import { AuctionListing } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/auction/profiles/profiles.controller.ts
+++ b/apps/v1/src/modules/auction/profiles/profiles.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { AuctionBid, AuctionListing, AuctionProfile } from "@prisma/v1-client"
+import { AuctionBid, AuctionListing, AuctionProfile } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { AuctionListingIncludes } from "../listings/listings.controller"

--- a/apps/v1/src/modules/auction/profiles/profiles.service.ts
+++ b/apps/v1/src/modules/auction/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { AuctionBid, AuctionListing, AuctionProfile } from "@prisma/v1-client"
+import { AuctionBid, AuctionListing, AuctionProfile } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/holidaze/bookings/booking.service.ts
+++ b/apps/v1/src/modules/holidaze/bookings/booking.service.ts
@@ -1,4 +1,4 @@
-import { HolidazeBooking } from "@prisma/v1-client"
+import { HolidazeBooking } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/holidaze/bookings/bookings.controller.ts
+++ b/apps/v1/src/modules/holidaze/bookings/bookings.controller.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from "fastify"
-import { HolidazeBooking, HolidazeProfile } from "@prisma/v1-client"
+import { HolidazeBooking, HolidazeProfile } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { getVenue } from "../venues/venues.service"

--- a/apps/v1/src/modules/holidaze/profiles/profiles.controller.ts
+++ b/apps/v1/src/modules/holidaze/profiles/profiles.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { HolidazeBooking, HolidazeProfile, HolidazeVenue } from "@prisma/v1-client"
+import { HolidazeBooking, HolidazeProfile, HolidazeVenue } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { HolidazeBookingIncludes } from "../bookings/bookings.controller"

--- a/apps/v1/src/modules/holidaze/profiles/profiles.service.ts
+++ b/apps/v1/src/modules/holidaze/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { HolidazeBooking, HolidazeProfile, HolidazeVenue } from "@prisma/v1-client"
+import { HolidazeBooking, HolidazeProfile, HolidazeVenue } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/holidaze/venues/venues.controller.ts
+++ b/apps/v1/src/modules/holidaze/venues/venues.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { HolidazeProfile, HolidazeVenue } from "@prisma/v1-client"
+import { HolidazeProfile, HolidazeVenue } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { getProfile } from "../profiles/profiles.service"

--- a/apps/v1/src/modules/holidaze/venues/venues.service.ts
+++ b/apps/v1/src/modules/holidaze/venues/venues.service.ts
@@ -1,4 +1,4 @@
-import { HolidazeVenue } from "@prisma/v1-client"
+import { HolidazeVenue } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/social/posts/posts.controller.ts
+++ b/apps/v1/src/modules/social/posts/posts.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { Comment, Post, Prisma, Profile } from "@prisma/v1-client"
+import { Comment, Post, Prisma, Profile } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { CreateCommentSchema, CreatePostBaseSchema } from "./posts.schema"

--- a/apps/v1/src/modules/social/posts/posts.service.ts
+++ b/apps/v1/src/modules/social/posts/posts.service.ts
@@ -1,4 +1,4 @@
-import { Post } from "@prisma/v1-client"
+import { Post } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/social/profiles/profiles.controller.ts
+++ b/apps/v1/src/modules/social/profiles/profiles.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { Post, Profile } from "@prisma/v1-client"
+import { Post, Profile } from "@/prisma/generated/v1-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { PostIncludes } from "../posts/posts.controller"

--- a/apps/v1/src/modules/social/profiles/profiles.service.ts
+++ b/apps/v1/src/modules/social/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { Post, Profile } from "@prisma/v1-client"
+import { Post, Profile } from "@/prisma/generated/v1-client"
 
 import { prisma } from "@/utils"
 

--- a/apps/v1/src/modules/social/profiles/profiles.utils.ts
+++ b/apps/v1/src/modules/social/profiles/profiles.utils.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/v1-client"
+import { Prisma } from "@/prisma/generated/v1-client"
 
 import { FollowSchema } from "./profiles.schema"
 import { getProfile } from "./profiles.service"

--- a/apps/v1/src/utils/prisma.ts
+++ b/apps/v1/src/utils/prisma.ts
@@ -1,3 +1,3 @@
-import { PrismaClient } from "@prisma/v1-client"
+import { PrismaClient } from "@/prisma/generated/v1-client"
 
 export const prisma = new PrismaClient()

--- a/apps/v1/tsconfig.json
+++ b/apps/v1/tsconfig.json
@@ -13,7 +13,8 @@
     "strict": true,
     "skipLibCheck": true,
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@/prisma/*": ["../prisma/*"]
     }
   },
   "include": ["src/**/*", "types"],

--- a/apps/v2/jest.config.ts
+++ b/apps/v2/jest.config.ts
@@ -7,6 +7,7 @@ const jestConfig: JestConfigWithTsJest = {
   testTimeout: 20000,
   setupFilesAfterEnv: ["<rootDir>/src/test-utils/server.ts"],
   moduleNameMapper: {
+    "^@/prisma/(.*)$": "<rootDir>/prisma/$1",
     "^@/(.*)$": "<rootDir>/src/$1"
   },
   workerIdleMemoryLimit: "512MB",

--- a/apps/v2/prisma/schema.prisma
+++ b/apps/v2/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../node_modules/@prisma/v2-client"
+  output   = "../prisma/generated/v2-client"
 }
 
 datasource db {

--- a/apps/v2/prisma/schema.prisma
+++ b/apps/v2/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  output   = "../prisma/generated/v2-client"
+  output   = "./generated/v2-client"
 }
 
 datasource db {

--- a/apps/v2/prisma/seed.ts
+++ b/apps/v2/prisma/seed.ts
@@ -1,4 +1,3 @@
-import type { UserProfile } from "@/prisma/generated/v2-client"
 import { faker } from "@faker-js/faker"
 
 import { createListing, createListingBid } from "../src/modules/auction/listings/listings.service"
@@ -7,6 +6,7 @@ import { createBooking } from "../src/modules/holidaze/bookings/booking.service"
 import { createVenue } from "../src/modules/holidaze/venues/venues.service"
 import { createComment, createOrDeleteReaction, createPost } from "../src/modules/social/posts/posts.service"
 import { db } from "../src/utils"
+import type { UserProfile } from "./generated/v2-client"
 
 // Run the seed function and exit when done
 main()

--- a/apps/v2/prisma/seed.ts
+++ b/apps/v2/prisma/seed.ts
@@ -1,5 +1,5 @@
+import type { UserProfile } from "@/prisma/generated/v2-client"
 import { faker } from "@faker-js/faker"
-import type { UserProfile } from "@prisma/v2-client"
 
 import { createListing, createListingBid } from "../src/modules/auction/listings/listings.service"
 import { createProfile } from "../src/modules/auth/auth.service"

--- a/apps/v2/src/exceptions/errorHandler.ts
+++ b/apps/v2/src/exceptions/errorHandler.ts
@@ -1,5 +1,5 @@
 import type { FastifyError, FastifyReply, FastifyRequest } from "fastify"
-import { Prisma } from "@prisma/v2-client"
+import { Prisma } from "@/prisma/generated/v2-client"
 import { isHttpError } from "http-errors"
 import statuses from "statuses"
 import { ZodError, ZodIssueCode } from "zod"

--- a/apps/v2/src/modules/auction/listings/listings.controller.ts
+++ b/apps/v2/src/modules/auction/listings/listings.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { AuctionBid, AuctionListing, Prisma, UserProfile } from "@prisma/v2-client"
+import { AuctionBid, AuctionListing, Prisma, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { getProfile } from "./../profiles/profiles.service"

--- a/apps/v2/src/modules/auction/listings/listings.service.ts
+++ b/apps/v2/src/modules/auction/listings/listings.service.ts
@@ -1,4 +1,4 @@
-import { AuctionListing } from "@prisma/v2-client"
+import { AuctionListing } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/auction/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { AuctionBid, AuctionListing, UserProfile } from "@prisma/v2-client"
+import { AuctionBid, AuctionListing, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { AuctionListingIncludes } from "../listings/listings.controller"

--- a/apps/v2/src/modules/auction/profiles/profiles.service.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { AuctionBid, AuctionListing, UserProfile } from "@prisma/v2-client"
+import { AuctionBid, AuctionListing, UserProfile } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/auth/auth.controller.ts
+++ b/apps/v2/src/modules/auth/auth.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard, verifyPassword } from "@noroff/api-utils"
-import { UserProfile } from "@prisma/v2-client"
+import { UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Unauthorized } from "http-errors"
 
 import {

--- a/apps/v2/src/modules/blog/posts/posts.controller.ts
+++ b/apps/v2/src/modules/blog/posts/posts.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { BlogPost, UserProfile } from "@prisma/v2-client"
+import { BlogPost, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import {

--- a/apps/v2/src/modules/blog/posts/posts.service.ts
+++ b/apps/v2/src/modules/blog/posts/posts.service.ts
@@ -1,4 +1,4 @@
-import { BlogPost } from "@prisma/v2-client"
+import { BlogPost } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/books/books.controller.ts
+++ b/apps/v2/src/modules/books/books.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { Book } from "@prisma/v2-client"
+import { Book } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { bookParamsSchema } from "./books.schema"

--- a/apps/v2/src/modules/books/books.service.ts
+++ b/apps/v2/src/modules/books/books.service.ts
@@ -1,5 +1,5 @@
 import { getRandomNumber } from "@noroff/api-utils"
-import { Book } from "@prisma/v2-client"
+import { Book } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/catFacts/catFacts.controller.ts
+++ b/apps/v2/src/modules/catFacts/catFacts.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { CatFact } from "@prisma/v2-client"
+import { CatFact } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { catFactParamsSchema } from "./catFacts.schema"

--- a/apps/v2/src/modules/catFacts/catFacts.service.ts
+++ b/apps/v2/src/modules/catFacts/catFacts.service.ts
@@ -1,5 +1,5 @@
 import { getRandomNumber } from "@noroff/api-utils"
-import { CatFact } from "@prisma/v2-client"
+import { CatFact } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/gameHub/gameHub.controller.ts
+++ b/apps/v2/src/modules/gameHub/gameHub.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { GameHubProducts } from "@prisma/v2-client"
+import { GameHubProducts } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { gameHubParamsSchema } from "./gameHub.schema"

--- a/apps/v2/src/modules/gameHub/gameHub.service.ts
+++ b/apps/v2/src/modules/gameHub/gameHub.service.ts
@@ -1,4 +1,4 @@
-import { GameHubProducts } from "@prisma/v2-client"
+import { GameHubProducts } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/holidaze/bookings/booking.service.ts
+++ b/apps/v2/src/modules/holidaze/bookings/booking.service.ts
@@ -1,4 +1,4 @@
-import { HolidazeBooking } from "@prisma/v2-client"
+import { HolidazeBooking } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/holidaze/bookings/bookings.controller.ts
+++ b/apps/v2/src/modules/holidaze/bookings/bookings.controller.ts
@@ -1,5 +1,5 @@
 import { FastifyReply, FastifyRequest } from "fastify"
-import { HolidazeBooking, UserProfile } from "@prisma/v2-client"
+import { HolidazeBooking, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Conflict, Forbidden, NotFound } from "http-errors"
 
 import { getVenue } from "../venues/venues.service"

--- a/apps/v2/src/modules/holidaze/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/holidaze/profiles/profiles.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { HolidazeBooking, HolidazeVenue, UserProfile } from "@prisma/v2-client"
+import { HolidazeBooking, HolidazeVenue, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { HolidazeBookingIncludes } from "../bookings/bookings.controller"

--- a/apps/v2/src/modules/holidaze/profiles/profiles.service.ts
+++ b/apps/v2/src/modules/holidaze/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { HolidazeBooking, HolidazeVenue, UserProfile } from "@prisma/v2-client"
+import { HolidazeBooking, HolidazeVenue, UserProfile } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/holidaze/venues/venues.controller.ts
+++ b/apps/v2/src/modules/holidaze/venues/venues.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { HolidazeVenue, UserProfile } from "@prisma/v2-client"
+import { HolidazeVenue, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { getProfile } from "../profiles/profiles.service"

--- a/apps/v2/src/modules/holidaze/venues/venues.service.ts
+++ b/apps/v2/src/modules/holidaze/venues/venues.service.ts
@@ -1,4 +1,4 @@
-import { HolidazeVenue } from "@prisma/v2-client"
+import { HolidazeVenue } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/jokes/jokes.controller.ts
+++ b/apps/v2/src/modules/jokes/jokes.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { Joke } from "@prisma/v2-client"
+import { Joke } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { jokeParamsSchema } from "./jokes.schema"

--- a/apps/v2/src/modules/jokes/jokes.service.ts
+++ b/apps/v2/src/modules/jokes/jokes.service.ts
@@ -1,5 +1,5 @@
 import { getRandomNumber } from "@noroff/api-utils"
-import { Joke } from "@prisma/v2-client"
+import { Joke } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/nbaTeams/nbaTeams.controller.ts
+++ b/apps/v2/src/modules/nbaTeams/nbaTeams.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { NbaTeam } from "@prisma/v2-client"
+import { NbaTeam } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { nbaTeamParamsSchema } from "./nbaTeams.schema"

--- a/apps/v2/src/modules/nbaTeams/nbaTeams.service.ts
+++ b/apps/v2/src/modules/nbaTeams/nbaTeams.service.ts
@@ -1,5 +1,5 @@
 import { getRandomNumber } from "@noroff/api-utils"
-import { NbaTeam } from "@prisma/v2-client"
+import { NbaTeam } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/oldGames/oldGames.controller.ts
+++ b/apps/v2/src/modules/oldGames/oldGames.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { OldGame } from "@prisma/v2-client"
+import { OldGame } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { oldGameParamsSchema } from "./oldGames.schema"

--- a/apps/v2/src/modules/oldGames/oldGames.service.ts
+++ b/apps/v2/src/modules/oldGames/oldGames.service.ts
@@ -1,5 +1,5 @@
 import { getRandomNumber } from "@noroff/api-utils"
-import { OldGame } from "@prisma/v2-client"
+import { OldGame } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/onlineShop/onlineShop.controller.ts
+++ b/apps/v2/src/modules/onlineShop/onlineShop.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { OnlineShopProduct } from "@prisma/v2-client"
+import { OnlineShopProduct } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { onlineShopParamsSchema } from "./onlineShop.schema"

--- a/apps/v2/src/modules/onlineShop/onlineShop.service.ts
+++ b/apps/v2/src/modules/onlineShop/onlineShop.service.ts
@@ -1,4 +1,4 @@
-import { OnlineShopProduct } from "@prisma/v2-client"
+import { OnlineShopProduct } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/quotes/quotes.controller.ts
+++ b/apps/v2/src/modules/quotes/quotes.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { Quote } from "@prisma/v2-client"
+import { Quote } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { quoteParamsSchema } from "./quotes.schema"

--- a/apps/v2/src/modules/quotes/quotes.service.ts
+++ b/apps/v2/src/modules/quotes/quotes.service.ts
@@ -1,5 +1,5 @@
 import { getRandomNumber } from "@noroff/api-utils"
-import { Quote } from "@prisma/v2-client"
+import { Quote } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/rainyDays/rainyDays.controller.ts
+++ b/apps/v2/src/modules/rainyDays/rainyDays.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { RainyDaysProduct } from "@prisma/v2-client"
+import { RainyDaysProduct } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { rainyDaysParamsSchema } from "./rainyDays.schema"

--- a/apps/v2/src/modules/rainyDays/rainyDays.service.ts
+++ b/apps/v2/src/modules/rainyDays/rainyDays.service.ts
@@ -1,4 +1,4 @@
-import { RainyDaysProduct } from "@prisma/v2-client"
+import { RainyDaysProduct } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/social/posts/posts.controller.ts
+++ b/apps/v2/src/modules/social/posts/posts.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyReply, FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { SocialPost, UserProfile } from "@prisma/v2-client"
+import { SocialPost, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import {

--- a/apps/v2/src/modules/social/posts/posts.service.ts
+++ b/apps/v2/src/modules/social/posts/posts.service.ts
@@ -1,4 +1,4 @@
-import { SocialPost } from "@prisma/v2-client"
+import { SocialPost } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/social/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { mediaGuard } from "@noroff/api-utils"
-import { SocialPost, UserProfile } from "@prisma/v2-client"
+import { SocialPost, UserProfile } from "@/prisma/generated/v2-client"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
 import { SocialPostIncludes } from "../posts/posts.controller"

--- a/apps/v2/src/modules/social/profiles/profiles.service.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.service.ts
@@ -1,4 +1,4 @@
-import { SocialPost, UserProfile } from "@prisma/v2-client"
+import { SocialPost, UserProfile } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/modules/social/profiles/profiles.utils.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.utils.ts
@@ -1,4 +1,4 @@
-import { Prisma } from "@prisma/v2-client"
+import { Prisma } from "@/prisma/generated/v2-client"
 
 import { getProfile } from "./profiles.service"
 

--- a/apps/v2/src/modules/squareEyes/squareEyes.controller.ts
+++ b/apps/v2/src/modules/squareEyes/squareEyes.controller.ts
@@ -1,6 +1,6 @@
 import { FastifyRequest } from "fastify"
 import { sortAndPaginationSchema } from "@noroff/api-utils"
-import { SquareEyesProduct } from "@prisma/v2-client"
+import { SquareEyesProduct } from "@/prisma/generated/v2-client"
 import { BadRequest, NotFound } from "http-errors"
 
 import { squareEyesParamsSchema } from "./squareEyes.schema"

--- a/apps/v2/src/modules/squareEyes/squareEyes.service.ts
+++ b/apps/v2/src/modules/squareEyes/squareEyes.service.ts
@@ -1,4 +1,4 @@
-import { SquareEyesProduct } from "@prisma/v2-client"
+import { SquareEyesProduct } from "@/prisma/generated/v2-client"
 
 import { db } from "@/utils"
 

--- a/apps/v2/src/utils/prisma.ts
+++ b/apps/v2/src/utils/prisma.ts
@@ -1,4 +1,4 @@
-import { PrismaClient } from "@prisma/v2-client"
+import { PrismaClient } from "@/prisma/generated/v2-client"
 import pagination from "prisma-extension-pagination"
 
 export const db = new PrismaClient().$extends(

--- a/apps/v2/tsconfig.json
+++ b/apps/v2/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "types": ["@types/jest"],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@/prisma/*": ["../prisma/*"]
     }
   },
   "ts-node": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.3",
-    "turbo": "^1.10.14"
+    "turbo": "^1.13.3"
   },
   "lint-staged": {
     "*": "prettier --ignore-unknown --write .",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
 
+  apps/v1/prisma/generated/v1-client: {}
+
   apps/v2:
     dependencies:
       "@fastify/autoload":
@@ -313,6 +315,8 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
+
+  apps/v2/prisma/generated/v2-client: {}
 
   packages/api-utils:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,8 +199,6 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
 
-  apps/v1/prisma/generated/v1-client: {}
-
   apps/v2:
     dependencies:
       "@fastify/autoload":

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,8 +41,8 @@ importers:
         specifier: ^3.0.3
         version: 3.0.3
       turbo:
-        specifier: ^1.10.14
-        version: 1.10.15
+        specifier: ^1.13.3
+        version: 1.13.3
 
   apps/docs:
     dependencies:
@@ -199,8 +199,6 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
 
-  apps/v1/prisma/generated/v1-client: {}
-
   apps/v2:
     dependencies:
       "@fastify/autoload":
@@ -315,8 +313,6 @@ importers:
       typescript:
         specifier: ^5.2.2
         version: 5.2.2
-
-  apps/v2/prisma/generated/v2-client: {}
 
   packages/api-utils:
     dependencies:
@@ -5146,45 +5142,45 @@ packages:
     resolution:
       { integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w== }
 
-  turbo-darwin-64@1.10.15:
+  turbo-darwin-64@1.13.3:
     resolution:
-      { integrity: sha512-Sik5uogjkRTe1XVP9TC2GryEMOJCaKE2pM/O9uLn4koQDnWKGcLQv+mDU+H+9DXvKLnJnKCD18OVRkwK5tdpoA== }
+      { integrity: sha512-glup8Qx1qEFB5jerAnXbS8WrL92OKyMmg5Hnd4PleLljAeYmx+cmmnsmLT7tpaVZIN58EAAwu8wHC6kIIqhbWA== }
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.10.15:
+  turbo-darwin-arm64@1.13.3:
     resolution:
-      { integrity: sha512-xwqyFDYUcl2xwXyGPmHkmgnNm4Cy0oNzMpMOBGRr5x64SErS7QQLR4VHb0ubiR+VAb8M+ECPklU6vD1Gm+wekg== }
+      { integrity: sha512-/np2xD+f/+9qY8BVtuOQXRq5f9LehCFxamiQnwdqWm5iZmdjygC5T3uVSYuagVFsZKMvX3ycySwh8dylGTl6lg== }
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@1.10.15:
+  turbo-linux-64@1.13.3:
     resolution:
-      { integrity: sha512-dM07SiO3RMAJ09Z+uB2LNUSkPp3I1IMF8goH5eLj+d8Kkwoxd/+qbUZOj9RvInyxU/IhlnO9w3PGd3Hp14m/nA== }
+      { integrity: sha512-G+HGrau54iAnbXLfl+N/PynqpDwi/uDzb6iM9hXEDG+yJnSJxaHMShhOkXYJPk9offm9prH33Khx2scXrYVW1g== }
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.10.15:
+  turbo-linux-arm64@1.13.3:
     resolution:
-      { integrity: sha512-MkzKLkKYKyrz4lwfjNXH8aTny5+Hmiu4SFBZbx+5C0vOlyp6fV5jZANDBvLXWiDDL4DSEAuCEK/2cmN6FVH1ow== }
+      { integrity: sha512-qWwEl5VR02NqRyl68/3pwp3c/olZuSp+vwlwrunuoNTm6JXGLG5pTeme4zoHNnk0qn4cCX7DFrOboArlYxv0wQ== }
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@1.10.15:
+  turbo-windows-64@1.13.3:
     resolution:
-      { integrity: sha512-3TdVU+WEH9ThvQGwV3ieX/XHebtYNHv9HARHauPwmVj3kakoALkpGxLclkHFBLdLKkqDvmHmXtcsfs6cXXRHJg== }
+      { integrity: sha512-Nudr4bRChfJzBPzEmpVV85VwUYRCGKecwkBFpbp2a4NtrJ3+UP1VZES653ckqCu2FRyRuS0n03v9euMbAvzH+Q== }
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.10.15:
+  turbo-windows-arm64@1.13.3:
     resolution:
-      { integrity: sha512-l+7UOBCbfadvPMYsX08hyLD+UIoAkg6ojfH+E8aud3gcA1padpjCJTh9gMpm3QdMbKwZteT5uUM+wyi6Rbbyww== }
+      { integrity: sha512-ouJCgsVLd3icjRLmRvHQDDZnmGzT64GBupM1Y+TjtYn2LVaEBoV6hicFy8x5DUpnqdLy+YpCzRMkWlwhmkX7sQ== }
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.10.15:
+  turbo@1.13.3:
     resolution:
-      { integrity: sha512-mKKkqsuDAQy1wCCIjCdG+jOCwUflhckDMSRoeBPcIL/CnCl7c5yRDFe7SyaXloUUkt4tUR0rvNIhVCcT7YeQpg== }
+      { integrity: sha512-n17HJv4F4CpsYTvKzUJhLbyewbXjq1oLCi90i5tW1TiWDz16ML1eDG7wi5dHaKxzh5efIM56SITnuVbMq5dk4g== }
     hasBin: true
 
   type-check@0.4.0:
@@ -10146,32 +10142,32 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@1.10.15:
+  turbo-darwin-64@1.13.3:
     optional: true
 
-  turbo-darwin-arm64@1.10.15:
+  turbo-darwin-arm64@1.13.3:
     optional: true
 
-  turbo-linux-64@1.10.15:
+  turbo-linux-64@1.13.3:
     optional: true
 
-  turbo-linux-arm64@1.10.15:
+  turbo-linux-arm64@1.13.3:
     optional: true
 
-  turbo-windows-64@1.10.15:
+  turbo-windows-64@1.13.3:
     optional: true
 
-  turbo-windows-arm64@1.10.15:
+  turbo-windows-arm64@1.13.3:
     optional: true
 
-  turbo@1.10.15:
+  turbo@1.13.3:
     optionalDependencies:
-      turbo-darwin-64: 1.10.15
-      turbo-darwin-arm64: 1.10.15
-      turbo-linux-64: 1.10.15
-      turbo-linux-arm64: 1.10.15
-      turbo-windows-64: 1.10.15
-      turbo-windows-arm64: 1.10.15
+      turbo-darwin-64: 1.13.3
+      turbo-darwin-arm64: 1.13.3
+      turbo-linux-64: 1.13.3
+      turbo-linux-arm64: 1.13.3
+      turbo-windows-64: 1.13.3
+      turbo-windows-arm64: 1.13.3
 
   type-check@0.4.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -199,6 +199,8 @@ importers:
         specifier: ^5.2.2
         version: 5.2.2
 
+  apps/v1/prisma/generated/v1-client: {}
+
   apps/v2:
     dependencies:
       "@fastify/autoload":

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,6 @@
 packages:
-  - "apps/**"
-  - "packages/**"
-  - "tooling/**"
-  - "!**/.next/**" # Ignore Next.js build output
-  - "!**/dist/**" # Ignore TypeScript build output
+  - "apps/*"
+  - "packages/*"
+  - "tooling/*"
+  - "!**/.next/*" # Ignore Next.js build output
+  - "!**/dist/*" # Ignore TypeScript build output


### PR DESCRIPTION
Changes the generated prisma clients location to be outside of node_modules. pnpm uses their own `node_modules/.pnpm` folder with custom structure and thus fails to find the prisma client when using it e.g in tests.