### PR TITLE
fix: Use name for profile lookup

### DIFF
--- a/apps/v2/src/modules/social/posts/posts.controller.ts
+++ b/apps/v2/src/modules/social/posts/posts.controller.ts
@@ -270,7 +270,7 @@ export async function getPostsOfFollowedUsersHandler(
     }
   }>
 ) {
-  const { id } = request.user as UserProfile
+  const { name } = request.user as UserProfile
   const { sort, sortOrder, limit, page, _author, _reactions, _comments, _tag } =
     request.query
 
@@ -285,7 +285,7 @@ export async function getPostsOfFollowedUsersHandler(
   }
 
   const posts = await getPostsOfFollowedUsers(
-    id,
+    name,
     sort,
     sortOrder,
     limit,

--- a/apps/v2/src/modules/social/posts/posts.service.ts
+++ b/apps/v2/src/modules/social/posts/posts.service.ts
@@ -336,7 +336,7 @@ export const getComment = async (id: number) => {
 }
 
 export const getPostsOfFollowedUsers = async (
-  id: number,
+  name: string,
   sort: keyof SocialPost = "created",
   sortOrder: "asc" | "desc" = "desc",
   limit = 100,
@@ -362,7 +362,7 @@ export const getPostsOfFollowedUsers = async (
         ...whereTag,
         author: {
           followers: {
-            some: { id }
+            some: { name }
           }
         }
       },


### PR DESCRIPTION
We relied on the `id` property when doing a lookup of followed users, but the JWT does not include the `id` property. This was removed in #172 and this bug has existed for quite some time.

We should update the type assertion here from `as UserProfile` to `as Pick<UserProfile, "name" | "email">` as well.