### PR TITLE
Custom RequestUser type

### DIFF
--- a/apps/v2/src/modules/auction/listings/listings.controller.ts
+++ b/apps/v2/src/modules/auction/listings/listings.controller.ts
@@ -8,6 +8,7 @@ import type {
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import { getProfile } from "./../profiles/profiles.service"
 import {
   type CreateListingSchema,
@@ -116,7 +117,7 @@ export async function createListingHandler(
   }>,
   reply: FastifyReply
 ) {
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { media } = await mediaSchema.parseAsync(request.body)
   const { _bids, _seller } = await queryFlagsSchema.parseAsync(request.query)
 
@@ -149,7 +150,7 @@ export async function updateListingHandler(
   const { id } = await listingIdParamsSchema.parseAsync(request.params)
   const { _bids, _seller } = await queryFlagsSchema.parseAsync(request.query)
   const { media } = await mediaSchema.parseAsync(request.body)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
 
   const includes: AuctionListingIncludes = {
     bids: Boolean(_bids),
@@ -184,7 +185,7 @@ export async function deleteListingHandler(
   reply: FastifyReply
 ) {
   const { id } = await listingIdParamsSchema.parseAsync(request.params)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
 
   const listing = await getListing(id)
 
@@ -214,7 +215,7 @@ export async function createListingBidHandler(
 ) {
   const { id } = await listingIdParamsSchema.parseAsync(request.params)
   const { amount } = await bidBodySchema.parseAsync(request.body)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { _bids, _seller } = await queryFlagsSchema.parseAsync(request.query)
 
   const includes: AuctionListingIncludes = {

--- a/apps/v2/src/modules/auction/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/auction/profiles/profiles.controller.ts
@@ -3,6 +3,7 @@ import type { AuctionBid, AuctionListing, UserProfile } from "@prisma/v2-client"
 import type { FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import type { AuctionListingIncludes } from "../listings/listings.controller"
 import { listingQuerySchema } from "../listings/listings.schema"
 import {
@@ -94,7 +95,7 @@ export async function updateProfileHandler(
   const { name: profileToUpdate } = await profileNameSchema.parseAsync(
     request.params
   )
-  const { name: requesterProfile } = request.user as UserProfile
+  const { name: requesterProfile } = request.user as RequestUser
 
   const profileExists = await getProfile(profileToUpdate)
 
@@ -177,7 +178,7 @@ export async function getProfileCreditsHandler(
   }>
 ) {
   const { name } = await profileNameSchema.parseAsync(request.params)
-  const { name: reqName } = request.user as UserProfile
+  const { name: reqName } = request.user as RequestUser
 
   const profile = await getProfile(name)
 

--- a/apps/v2/src/modules/auth/auth.controller.ts
+++ b/apps/v2/src/modules/auth/auth.controller.ts
@@ -1,8 +1,8 @@
 import { mediaGuard, verifyPassword } from "@noroff/api-utils"
-import type { UserProfile } from "@prisma/v2-client"
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { BadRequest, Unauthorized } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import {
   type CreateAPIKeyInput,
   type CreateProfileInput,
@@ -86,6 +86,7 @@ export async function loginHandler(
   return {
     data: {
       ...rest,
+      // accessToken should match RequestUser type from types/api.ts
       accessToken: request.jwt.sign({
         name: rest.name,
         email: rest.email
@@ -101,7 +102,7 @@ export async function createApiKeyHandler(
   reply: FastifyReply
 ) {
   await createApiKeySchema.parseAsync(request.body)
-  const { name: userName } = request.user as UserProfile
+  const { name: userName } = request.user as RequestUser
 
   const apiKey = await createApiKey(userName, request.body?.name)
 

--- a/apps/v2/src/modules/blog/posts/posts.controller.ts
+++ b/apps/v2/src/modules/blog/posts/posts.controller.ts
@@ -1,8 +1,9 @@
 import { mediaGuard } from "@noroff/api-utils"
-import type { BlogPost, UserProfile } from "@prisma/v2-client"
+import type { BlogPost } from "@prisma/v2-client"
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import {
   type CreatePostBaseSchema,
   mediaSchema,
@@ -75,7 +76,7 @@ export async function createPostHandler(
     request.params
   )
   await mediaSchema.parseAsync(request.body)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { media } = request.body
 
   if (name.toLowerCase() !== paramsName.toLowerCase()) {
@@ -105,7 +106,7 @@ export async function deletePostHandler(
   const { id, name: paramsName } = await postIdWithNameParamsSchema.parseAsync(
     request.params
   )
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
 
   if (name.toLowerCase() !== paramsName.toLowerCase()) {
     throw new Forbidden("You do not have permission to delete this post")
@@ -134,7 +135,7 @@ export async function updatePostHandler(
   const { id, name: paramsName } = await postIdWithNameParamsSchema.parseAsync(
     request.params
   )
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { media } = request.body
 
   if (name.toLowerCase() !== paramsName.toLowerCase()) {

--- a/apps/v2/src/modules/holidaze/bookings/bookings.controller.ts
+++ b/apps/v2/src/modules/holidaze/bookings/bookings.controller.ts
@@ -1,7 +1,8 @@
-import type { HolidazeBooking, UserProfile } from "@prisma/v2-client"
+import type { HolidazeBooking } from "@prisma/v2-client"
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { BadRequest, Conflict, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import { getVenue } from "../venues/venues.service"
 import {
   createBooking,
@@ -92,7 +93,7 @@ export async function createBookingHandler(
   reply: FastifyReply
 ) {
   await createBookingSchema.parseAsync(request.body)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { _customer, _venue } = await queryFlagsSchema.parseAsync(request.query)
 
   const includes: HolidazeBookingIncludes = {
@@ -142,7 +143,7 @@ export async function updateBookingHandler(
   }>
 ) {
   const { guests } = await updateBookingSchema.parseAsync(request.body)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { id } = await bookingIdSchema.parseAsync(request.params)
   const { _customer, _venue } = request.query
 
@@ -180,7 +181,7 @@ export async function deleteBookingHandler(
   }>,
   reply: FastifyReply
 ) {
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { id } = await bookingIdSchema.parseAsync(request.params)
 
   const booking = await getBooking(id)

--- a/apps/v2/src/modules/holidaze/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/holidaze/profiles/profiles.controller.ts
@@ -7,6 +7,7 @@ import type {
 import type { FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import type { HolidazeBookingIncludes } from "../bookings/bookings.controller"
 import type { HolidazeVenueIncludes } from "../venues/venues.controller"
 import {
@@ -100,7 +101,7 @@ export async function updateProfileHandler(
   const { name: profileToUpdate } = await profileNameSchema.parseAsync(
     request.params
   )
-  const { name: requesterProfile } = request.user as UserProfile
+  const { name: requesterProfile } = request.user as RequestUser
 
   const profile = await getProfile(profileToUpdate)
 

--- a/apps/v2/src/modules/holidaze/venues/venues.controller.ts
+++ b/apps/v2/src/modules/holidaze/venues/venues.controller.ts
@@ -1,8 +1,9 @@
 import { mediaGuard } from "@noroff/api-utils"
-import type { HolidazeVenue, UserProfile } from "@prisma/v2-client"
+import type { HolidazeVenue } from "@prisma/v2-client"
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import { getProfile } from "../profiles/profiles.service"
 import {
   type CreateVenueSchema,
@@ -93,7 +94,7 @@ export async function createVenueHandler(
   }>,
   reply: FastifyReply
 ) {
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { media } = await createVenueSchema.parseAsync(request.body)
   const { _owner, _bookings } = await queryFlagsSchema.parseAsync(request.query)
 
@@ -133,7 +134,7 @@ export async function updateVenueHandler(
     }
   }>
 ) {
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { id } = await venueIdSchema.parseAsync(request.params)
   const { media } = await updateVenueSchema.parseAsync(request.body)
   const { _owner, _bookings } = await queryFlagsSchema.parseAsync(request.query)
@@ -176,7 +177,7 @@ export async function deleteVenueHandler(
   }>,
   reply: FastifyReply
 ) {
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { id } = await venueIdSchema.parseAsync(request.params)
 
   const venue = await getVenue(id)

--- a/apps/v2/src/modules/social/posts/posts.controller.ts
+++ b/apps/v2/src/modules/social/posts/posts.controller.ts
@@ -1,8 +1,9 @@
 import { mediaGuard } from "@noroff/api-utils"
-import type { SocialPost, UserProfile } from "@prisma/v2-client"
+import type { SocialPost } from "@prisma/v2-client"
 import type { FastifyReply, FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import {
   type CreateCommentSchema,
   type CreatePostBaseSchema,
@@ -107,7 +108,7 @@ export async function createPostHandler(
   reply: FastifyReply
 ) {
   await mediaSchema.parseAsync(request.body)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { media } = request.body
   const { _author, _reactions, _comments } = request.query
 
@@ -133,7 +134,7 @@ export async function deletePostHandler(
   reply: FastifyReply
 ) {
   const { id } = await postIdParamsSchema.parseAsync(request.params)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
 
   const post = await getPost(id, { author: true })
 
@@ -162,7 +163,7 @@ export async function updatePostHandler(
   }>
 ) {
   const { id } = await postIdParamsSchema.parseAsync(request.params)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { media } = request.body
   const { _author, _reactions, _comments } = request.query
 
@@ -199,7 +200,7 @@ export async function createOrDeleteReactionHandler(
   const { id } = await postIdParamsSchema.parseAsync(request.params)
   const { symbol } = request.params
   await emojiSchema.parseAsync(symbol)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
 
   const post = await getPost(id)
 
@@ -222,7 +223,7 @@ export async function createCommentHandler(
 ) {
   const { id } = await postIdParamsSchema.parseAsync(request.params)
   const { _author } = await authorQuerySchema.parseAsync(request.query)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { replyToId } = request.body
 
   const post = await getPost(id, { comments: true })
@@ -270,7 +271,7 @@ export async function getPostsOfFollowedUsersHandler(
     }
   }>
 ) {
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
   const { sort, sortOrder, limit, page, _author, _reactions, _comments, _tag } =
     request.query
 
@@ -336,7 +337,7 @@ export async function deleteCommentHandler(
   reply: FastifyReply
 ) {
   const { id, commentId } = await deleteCommentSchema.parseAsync(request.params)
-  const { name } = request.user as UserProfile
+  const { name } = request.user as RequestUser
 
   const post = await getPost(id, { comments: true })
 

--- a/apps/v2/src/modules/social/profiles/profiles.controller.ts
+++ b/apps/v2/src/modules/social/profiles/profiles.controller.ts
@@ -3,6 +3,7 @@ import type { SocialPost, UserProfile } from "@prisma/v2-client"
 import type { FastifyRequest } from "fastify"
 import { BadRequest, Forbidden, NotFound } from "http-errors"
 
+import type { RequestUser } from "@/types/api"
 import type { SocialPostIncludes } from "../posts/posts.controller"
 import {
   type UpdateProfileSchema,
@@ -103,7 +104,7 @@ export async function updateProfileHandler(
 ) {
   const { avatar, banner, ...rest } = updateProfileSchema.parse(request.body)
   const { name: profileToUpdate } = profileNameSchema.parse(request.params)
-  const { name: requesterProfile } = request.user as UserProfile
+  const { name: requesterProfile } = request.user as RequestUser
 
   const profileExists = await getProfile(profileToUpdate)
 
@@ -137,7 +138,7 @@ export async function followProfileHandler(
   }>
 ) {
   const { name: target } = profileNameSchema.parse(request.params)
-  const { name: follower } = request.user as UserProfile
+  const { name: follower } = request.user as RequestUser
 
   if (target.toLowerCase() === follower.toLowerCase()) {
     throw new BadRequest("You can't follow yourself")
@@ -166,7 +167,7 @@ export async function unfollowProfileHandler(
   }>
 ) {
   const { name: target } = profileNameSchema.parse(request.params)
-  const { name: follower } = request.user as UserProfile
+  const { name: follower } = request.user as RequestUser
 
   if (target.toLowerCase() === follower.toLowerCase()) {
     throw new BadRequest("You can't unfollow yourself")

--- a/apps/v2/tsconfig.json
+++ b/apps/v2/tsconfig.json
@@ -14,7 +14,8 @@
     "skipLibCheck": true,
     "types": ["@types/jest"],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@/types/*": ["../types/*"]
     }
   },
   "ts-node": {

--- a/apps/v2/types/api.ts
+++ b/apps/v2/types/api.ts
@@ -1,0 +1,3 @@
+import type { UserProfile } from "@prisma/v2-client"
+
+export type RequestUser = Pick<UserProfile, "name" | "email">


### PR DESCRIPTION
Follow-up of #200 

- Add custom `RequestUser` type, picking fields from `UserProfile` that matches JWT.
- Replace `as UserProfile` with `as RequestUser` where applicable.