### PR TITLE
Separate install and build per workflow

### DIFF
--- a/.github/workflows/docs_build.yml
+++ b/.github/workflows/docs_build.yml
@@ -22,6 +22,6 @@ jobs:
       - name: Setup
         uses: ./tooling/github/setup
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --filter=docs...
       - name: Build @noroff/api-docs
-        run: "pnpm build:docs"
+        run: pnpm turbo run build --filter=docs...

--- a/.github/workflows/v1_build.yml
+++ b/.github/workflows/v1_build.yml
@@ -22,10 +22,6 @@ jobs:
       - name: Setup
         uses: ./tooling/github/setup
       - name: Install dependencies
-        run: pnpm install
-      - name: Build @noroff/api-utils
-        run: "pnpm build:api-utils"
-      - name: Build @noroff/logger
-        run: "pnpm build:logger"
+        run: pnpm install --filter=v1...
       - name: Build @noroff/api-v1
-        run: "pnpm build:v1"
+        run: pnpm turbo run build --filter=v1...

--- a/.github/workflows/v2_build_and_test.yml
+++ b/.github/workflows/v2_build_and_test.yml
@@ -22,13 +22,9 @@ jobs:
       - name: Setup
         uses: ./tooling/github/setup
       - name: Install dependencies
-        run: pnpm install
-      - name: Build @noroff/api-utils
-        run: "pnpm build:api-utils"
-      - name: Build @noroff/logger
-        run: "pnpm build:logger"
+        run: pnpm install --filter=v2...
       - name: Build @noroff/api-v2
-        run: "pnpm build:v2"
+        run: pnpm turbo run build --filter=v2...
 
   test:
     name: Test


### PR DESCRIPTION
Separate out the install and build for each GH Action. This will speed up our CI as it will only process the required files and not run any pre or post scripts. 
 
This should also remove install errors related to v1 or v2 when working with docs, as an example.