### PR TITLE
Upgrade turbo, fix docs build

### DIFF
--- a/.github/workflows/v2_build_and_test.yml
+++ b/.github/workflows/v2_build_and_test.yml
@@ -57,6 +57,9 @@ jobs:
         run: "pnpm build:api-utils"
       - name: Build @noroff/logger
         run: "pnpm build:logger"
+      - name: Generate Prisma Client
+        run: pnpm prisma generate
+        working-directory: apps/v2
       - name: Run Prisma migrations
         run: pnpm prisma migrate deploy
         working-directory: apps/v2

--- a/apps/docs/Dockerfile
+++ b/apps/docs/Dockerfile
@@ -19,6 +19,7 @@ COPY .gitignore .gitignore
 COPY turbo.json turbo.json
 COPY --from=builder /app/out/json/ .
 COPY --from=builder /app/out/pnpm-lock.yaml ./pnpm-lock.yaml
+COPY --from=builder /app/apps/docs/source.config.ts ./apps/docs/source.config.ts
 RUN pnpm install
 COPY --from=builder /app/out/full/ .
 

--- a/apps/docs/tsconfig.json
+++ b/apps/docs/tsconfig.json
@@ -14,7 +14,6 @@
     "resolveJsonModule": true,
     "isolatedModules": true,
     "jsx": "preserve",
-    "incremental": true,
     "paths": {
       "@/*": ["./*"]
     },

--- a/apps/v1/package.json
+++ b/apps/v1/package.json
@@ -10,6 +10,7 @@
     "start:migrate:prod": "pnpm prisma migrate deploy && pnpm start",
     "build": "tsup",
     "prebuild": "pnpm prisma generate",
+    "prisma:generate": "pnpm prisma generate",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
     "format": "biome format .",

--- a/apps/v1/package.json
+++ b/apps/v1/package.json
@@ -10,7 +10,6 @@
     "start:migrate:prod": "pnpm prisma migrate deploy && pnpm start",
     "build": "tsup",
     "prebuild": "pnpm prisma generate",
-    "postinstall": "pnpm prisma generate",
     "typecheck": "tsc --noEmit",
     "lint": "biome lint .",
     "format": "biome format .",

--- a/apps/v1/src/hooks/logger.ts
+++ b/apps/v1/src/hooks/logger.ts
@@ -31,7 +31,7 @@ export default fp(async fastify => {
       url: req.url,
       method: req.method,
       statusCode: reply.statusCode,
-      responseTime: reply.getResponseTime()
+      responseTime: reply.elapsedTime
     })
     return next()
   })

--- a/apps/v2/package.json
+++ b/apps/v2/package.json
@@ -10,6 +10,7 @@
     "start:migrate:prod": "pnpm prisma migrate deploy && pnpm start",
     "build": "tsup",
     "prebuild": "pnpm prisma generate",
+    "prisma:generate": "pnpm prisma generate",
     "db:seed": "prisma db seed",
     "docker:up": "docker-compose -f ./docker-compose.tests.yml up -d",
     "docker:down": "docker-compose -f ./docker-compose.tests.yml down",

--- a/apps/v2/package.json
+++ b/apps/v2/package.json
@@ -10,7 +10,6 @@
     "start:migrate:prod": "pnpm prisma migrate deploy && pnpm start",
     "build": "tsup",
     "prebuild": "pnpm prisma generate",
-    "postinstall": "pnpm prisma generate",
     "db:seed": "prisma db seed",
     "docker:up": "docker-compose -f ./docker-compose.tests.yml up -d",
     "docker:down": "docker-compose -f ./docker-compose.tests.yml down",

--- a/apps/v2/prisma/seed.ts
+++ b/apps/v2/prisma/seed.ts
@@ -1,5 +1,6 @@
 import { faker } from "@faker-js/faker"
 
+import type { UserProfile } from "@prisma/v2-client"
 import {
   createListing,
   createListingBid
@@ -13,7 +14,6 @@ import {
   createPost
 } from "../src/modules/social/posts/posts.service"
 import { db } from "../src/utils"
-import type { UserProfile } from "./generated/v2-client"
 
 // Run the seed function and exit when done
 main()

--- a/apps/v2/src/hooks/logger.ts
+++ b/apps/v2/src/hooks/logger.ts
@@ -32,7 +32,7 @@ export default fp(async fastify => {
       url: req.url,
       method: req.method,
       statusCode: reply.statusCode,
-      responseTime: reply.getResponseTime()
+      responseTime: reply.elapsedTime
     })
     return next()
   })

--- a/apps/v2/src/modules/auction/listings/__tests__/createListing.test.ts
+++ b/apps/v2/src/modules/auction/listings/__tests__/createListing.test.ts
@@ -101,6 +101,11 @@ describe("[POST] /auction/listings", () => {
         path: ["title"]
       },
       {
+        code: "invalid_date",
+        message: "Invalid date",
+        path: ["endsAt"]
+      },
+      {
         code: "invalid_type",
         message: "Tags must be an array of strings",
         path: ["tags"]

--- a/apps/v2/src/modules/holidaze/bookings/__tests__/createBooking.test.ts
+++ b/apps/v2/src/modules/holidaze/bookings/__tests__/createBooking.test.ts
@@ -242,6 +242,11 @@ describe("[POST] /holidaze/bookings", () => {
         path: ["dateFrom"]
       },
       {
+        code: "invalid_date",
+        message: "Invalid date",
+        path: ["dateTo"]
+      },
+      {
         code: "invalid_type",
         message: "Guests must be a number",
         path: ["guests"]

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "concurrently": "^8.2.1",
     "husky": "^8.0.3",
     "lint-staged": "^14.0.1",
-    "turbo": "^1.13.3"
+    "turbo": "^2.3.4"
   },
   "lint-staged": {
     "*": "biome check --no-errors-on-unmatched --files-ignore-unknown=true",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^14.0.1
         version: 14.0.1
       turbo:
-        specifier: ^1.13.3
-        version: 1.13.4
+        specifier: ^2.3.4
+        version: 2.3.4
 
   apps/docs:
     dependencies:
@@ -4670,38 +4670,38 @@ packages:
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
 
-  turbo-darwin-64@1.13.4:
-    resolution: {integrity: sha512-A0eKd73R7CGnRinTiS7txkMElg+R5rKFp9HV7baDiEL4xTG1FIg/56Vm7A5RVgg8UNgG2qNnrfatJtb+dRmNdw==}
+  turbo-darwin-64@2.3.4:
+    resolution: {integrity: sha512-uOi/cUIGQI7uakZygH+cZQ5D4w+aMLlVCN2KTGot+cmefatps2ZmRRufuHrEM0Rl63opdKD8/JIu+54s25qkfg==}
     cpu: [x64]
     os: [darwin]
 
-  turbo-darwin-arm64@1.13.4:
-    resolution: {integrity: sha512-eG769Q0NF6/Vyjsr3mKCnkG/eW6dKMBZk6dxWOdrHfrg6QgfkBUk0WUUujzdtVPiUIvsh4l46vQrNVd9EOtbyA==}
+  turbo-darwin-arm64@2.3.4:
+    resolution: {integrity: sha512-IIM1Lq5R+EGMtM1YFGl4x8Xkr0MWb4HvyU8N4LNoQ1Be5aycrOE+VVfH+cDg/Q4csn+8bxCOxhRp5KmUflrVTQ==}
     cpu: [arm64]
     os: [darwin]
 
-  turbo-linux-64@1.13.4:
-    resolution: {integrity: sha512-Bq0JphDeNw3XEi+Xb/e4xoKhs1DHN7OoLVUbTIQz+gazYjigVZvtwCvgrZI7eW9Xo1eOXM2zw2u1DGLLUfmGkQ==}
+  turbo-linux-64@2.3.4:
+    resolution: {integrity: sha512-1aD2EfR7NfjFXNH3mYU5gybLJEFi2IGOoKwoPLchAFRQ6OEJQj201/oNo9CDL75IIrQo64/NpEgVyZtoPlfhfA==}
     cpu: [x64]
     os: [linux]
 
-  turbo-linux-arm64@1.13.4:
-    resolution: {integrity: sha512-BJcXw1DDiHO/okYbaNdcWN6szjXyHWx9d460v6fCHY65G8CyqGU3y2uUTPK89o8lq/b2C8NK0yZD+Vp0f9VoIg==}
+  turbo-linux-arm64@2.3.4:
+    resolution: {integrity: sha512-MxTpdKwxCaA5IlybPxgGLu54fT2svdqTIxRd0TQmpRJIjM0s4kbM+7YiLk0mOh6dGqlWPUsxz/A0Mkn8Xr5o7Q==}
     cpu: [arm64]
     os: [linux]
 
-  turbo-windows-64@1.13.4:
-    resolution: {integrity: sha512-OFFhXHOFLN7A78vD/dlVuuSSVEB3s9ZBj18Tm1hk3aW1HTWTuAw0ReN6ZNlVObZUHvGy8d57OAGGxf2bT3etQw==}
+  turbo-windows-64@2.3.4:
+    resolution: {integrity: sha512-yyCrWqcRGu1AOOlrYzRnizEtdkqi+qKP0MW9dbk9OsMDXaOI5jlWtTY/AtWMkLw/czVJ7yS9Ex1vi9DB6YsFvw==}
     cpu: [x64]
     os: [win32]
 
-  turbo-windows-arm64@1.13.4:
-    resolution: {integrity: sha512-u5A+VOKHswJJmJ8o8rcilBfU5U3Y1TTAfP9wX8bFh8teYF1ghP0EhtMRLjhtp6RPa+XCxHHVA2CiC3gbh5eg5g==}
+  turbo-windows-arm64@2.3.4:
+    resolution: {integrity: sha512-PggC3qH+njPfn1PDVwKrQvvQby8X09ufbqZ2Ha4uSu+5TvPorHHkAbZVHKYj2Y+tvVzxRzi4Sv6NdHXBS9Be5w==}
     cpu: [arm64]
     os: [win32]
 
-  turbo@1.13.4:
-    resolution: {integrity: sha512-1q7+9UJABuBAHrcC4Sxp5lOqYS5mvxRrwa33wpIyM18hlOCpRD/fTJNxZ0vhbMcJmz15o9kkVm743mPn7p6jpQ==}
+  turbo@2.3.4:
+    resolution: {integrity: sha512-1kiLO5C0Okh5ay1DbHsxkPsw9Sjsbjzm6cF85CpWjR0BIyBFNDbKqtUyqGADRS1dbbZoQanJZVj4MS5kk8J42Q==}
     hasBin: true
 
   type-detect@4.0.8:
@@ -9813,32 +9813,32 @@ snapshots:
     dependencies:
       safe-buffer: 5.2.1
 
-  turbo-darwin-64@1.13.4:
+  turbo-darwin-64@2.3.4:
     optional: true
 
-  turbo-darwin-arm64@1.13.4:
+  turbo-darwin-arm64@2.3.4:
     optional: true
 
-  turbo-linux-64@1.13.4:
+  turbo-linux-64@2.3.4:
     optional: true
 
-  turbo-linux-arm64@1.13.4:
+  turbo-linux-arm64@2.3.4:
     optional: true
 
-  turbo-windows-64@1.13.4:
+  turbo-windows-64@2.3.4:
     optional: true
 
-  turbo-windows-arm64@1.13.4:
+  turbo-windows-arm64@2.3.4:
     optional: true
 
-  turbo@1.13.4:
+  turbo@2.3.4:
     optionalDependencies:
-      turbo-darwin-64: 1.13.4
-      turbo-darwin-arm64: 1.13.4
-      turbo-linux-64: 1.13.4
-      turbo-linux-arm64: 1.13.4
-      turbo-windows-64: 1.13.4
-      turbo-windows-arm64: 1.13.4
+      turbo-darwin-64: 2.3.4
+      turbo-darwin-arm64: 2.3.4
+      turbo-linux-64: 2.3.4
+      turbo-linux-arm64: 2.3.4
+      turbo-windows-64: 2.3.4
+      turbo-windows-arm64: 2.3.4
 
   type-detect@4.0.8: {}
 

--- a/turbo.json
+++ b/turbo.json
@@ -20,7 +20,7 @@
     },
     "typecheck": {
       "dependsOn": ["^topo", "^build"],
-      "outputs": ["node_modules/.cache/tsbuildinfo.json"]
+      "outputs": []
     },
     "format": {
       "outputLogs": "new-only"

--- a/turbo.json
+++ b/turbo.json
@@ -19,8 +19,11 @@
       "cache": false
     },
     "typecheck": {
-      "dependsOn": ["^topo", "^build"],
+      "dependsOn": ["^topo", "^build", "prisma:generate"],
       "outputs": []
+    },
+    "prisma:generate": {
+      "cache": false
     },
     "format": {
       "outputLogs": "new-only"

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,6 @@
 {
-  "$schema": "https://turbo.build/schema.v1.json",
-  "pipeline": {
+  "$schema": "https://turbo.build/schema.v2.json",
+  "tasks": {
     "topo": {
       "dependsOn": ["^topo"]
     },
@@ -23,7 +23,7 @@
       "outputs": ["node_modules/.cache/tsbuildinfo.json"]
     },
     "format": {
-      "outputMode": "new-only"
+      "outputLogs": "new-only"
     },
     "lint": {
       "dependsOn": ["^topo", "^build"]


### PR DESCRIPTION
- Upgrade turbo to version 2
- Fixes docs dockerfile build by copying over required config file before build
- Remove unnecessary postinstall scripts from v1 and v2
- Fix type import in v2 prisma seed script.