### PR TITLE
Fix recipe comment param contract and add tests

### DIFF
--- a/apps/v2/src/modules/recipeBook/comments/__tests__/getRecipeComments.test.ts
+++ b/apps/v2/src/modules/recipeBook/comments/__tests__/getRecipeComments.test.ts
@@ -46,7 +46,7 @@ afterEach(async () => {
   await db.$disconnect()
 })
 
-describe("[GET] /recipe-book/recipes/:recipeId/comments", () => {
+describe("[GET] /recipe-book/recipes/:id/comments", () => {
   it("should return comments for a recipe", async () => {
     const response = await server.inject({
       url: `/recipe-book/recipes/${RECIPE_ID}/comments`,

--- a/apps/v2/src/modules/recipeBook/recipes/__tests__/createRecipeComment.test.ts
+++ b/apps/v2/src/modules/recipeBook/recipes/__tests__/createRecipeComment.test.ts
@@ -2,10 +2,10 @@ import { getAuthCredentials, server } from "@/test-utils"
 
 import { db } from "@/utils"
 
-let BEARER_TOKEN = ""
 let API_KEY = ""
-let USER_NAME = ""
+let BEARER_TOKEN = ""
 let RECIPE_ID = ""
+let USER_NAME = ""
 
 beforeEach(async () => {
   const { bearerToken, apiKey, name } = await getAuthCredentials()
@@ -16,19 +16,20 @@ beforeEach(async () => {
 
   const recipe = await db.recipe.create({
     data: {
-      title: "Test Recipe",
-      description: "A test recipe.",
-      prepTime: 5,
-      cookTime: 10,
-      servings: 2,
+      title: "Roasted Vegetables",
+      description: "A tray of roasted vegetables.",
+      prepTime: 15,
+      cookTime: 35,
+      servings: 4,
       difficulty: "Easy",
-      category: "Test",
-      ingredients: [{ name: "Test", quantity: 1, unit: "piece" }],
-      instructions: ["Do the test."],
-      tags: [],
+      category: "Dinner",
+      ingredients: [{ name: "Carrots", quantity: 4, unit: "pcs" }],
+      instructions: ["Chop vegetables.", "Roast until tender."],
+      tags: ["Vegetarian"],
       ownerName: USER_NAME
     }
   })
+
   RECIPE_ID = recipe.id
 })
 
@@ -45,7 +46,7 @@ afterEach(async () => {
 })
 
 describe("[POST] /recipe-book/recipes/:id/comments", () => {
-  it("should return 201 when successfully created a comment", async () => {
+  it("should create a recipe comment from the recipes module", async () => {
     const response = await server.inject({
       url: `/recipe-book/recipes/${RECIPE_ID}/comments`,
       method: "POST",
@@ -53,39 +54,19 @@ describe("[POST] /recipe-book/recipes/:id/comments", () => {
         Authorization: `Bearer ${BEARER_TOKEN}`,
         "X-Noroff-API-Key": API_KEY
       },
-      payload: { text: "Great recipe!" }
+      payload: { text: "This turned out great." }
     })
     const res = await response.json()
 
     expect(response.statusCode).toBe(201)
     expect(res.data).toMatchObject({
       id: expect.any(String),
-      text: "Great recipe!",
-      recipeId: RECIPE_ID
+      recipeId: RECIPE_ID,
+      text: "This turned out great.",
+      author: {
+        name: USER_NAME
+      }
     })
-  })
-
-  it("should return 404 for non-existent recipe", async () => {
-    const response = await server.inject({
-      url: "/recipe-book/recipes/00000000-0000-0000-0000-000000000000/comments",
-      method: "POST",
-      headers: {
-        Authorization: `Bearer ${BEARER_TOKEN}`,
-        "X-Noroff-API-Key": API_KEY
-      },
-      payload: { text: "Great recipe!" }
-    })
-
-    expect(response.statusCode).toBe(404)
-  })
-
-  it("should require authentication", async () => {
-    const response = await server.inject({
-      url: `/recipe-book/recipes/${RECIPE_ID}/comments`,
-      method: "POST",
-      payload: { text: "Great recipe!" }
-    })
-
-    expect(response.statusCode).toBe(401)
+    expect(res.meta).toStrictEqual({})
   })
 })

--- a/apps/v2/src/modules/recipeBook/recipes/__tests__/getRecipeComments.test.ts
+++ b/apps/v2/src/modules/recipeBook/recipes/__tests__/getRecipeComments.test.ts
@@ -1,0 +1,88 @@
+import { registerUser, server } from "@/test-utils"
+
+import { db } from "@/utils"
+
+const RECIPE_UUID = "a229424c-da96-4725-b112-4a880cc7f2e1"
+
+let USER_NAME = ""
+
+beforeEach(async () => {
+  const { name } = await registerUser()
+  USER_NAME = name
+
+  await db.recipe.create({
+    data: {
+      id: RECIPE_UUID,
+      title: "Tomato Soup",
+      description: "A simple tomato soup.",
+      prepTime: 10,
+      cookTime: 25,
+      servings: 4,
+      difficulty: "Easy",
+      category: "Soup",
+      ingredients: [{ name: "Tomatoes", quantity: 6, unit: "pcs" }],
+      instructions: ["Simmer ingredients.", "Blend until smooth."],
+      tags: ["Comfort food"],
+      ownerName: USER_NAME
+    }
+  })
+
+  await db.recipeComment.createMany({
+    data: [
+      {
+        text: "Perfect for lunch.",
+        recipeId: RECIPE_UUID,
+        ownerName: USER_NAME
+      },
+      {
+        text: "Adding basil worked well.",
+        recipeId: RECIPE_UUID,
+        ownerName: USER_NAME
+      }
+    ]
+  })
+})
+
+afterEach(async () => {
+  const mealPlans = db.mealPlan.deleteMany()
+  const favorites = db.recipeFavorite.deleteMany()
+  const comments = db.recipeComment.deleteMany()
+  const recipes = db.recipe.deleteMany()
+  const users = db.userProfile.deleteMany()
+  const media = db.media.deleteMany()
+
+  await db.$transaction([mealPlans, favorites, comments, recipes, users, media])
+  await db.$disconnect()
+})
+
+describe("[GET] /recipe-book/recipes/:id/comments", () => {
+  it("should return comments for a recipe from the recipes module", async () => {
+    const response = await server.inject({
+      url: `/recipe-book/recipes/${RECIPE_UUID}/comments`,
+      method: "GET"
+    })
+    const res = await response.json()
+
+    expect(response.statusCode).toBe(200)
+    expect(res.data).toHaveLength(2)
+    expect(res.data).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          recipeId: RECIPE_UUID,
+          text: "Perfect for lunch.",
+          author: expect.objectContaining({
+            name: USER_NAME
+          })
+        }),
+        expect.objectContaining({
+          recipeId: RECIPE_UUID,
+          text: "Adding basil worked well.",
+          author: expect.objectContaining({
+            name: USER_NAME
+          })
+        })
+      ])
+    )
+    expect(res.meta).toStrictEqual({})
+  })
+})

--- a/apps/v2/src/modules/recipeBook/recipes/recipes.controller.ts
+++ b/apps/v2/src/modules/recipeBook/recipes/recipes.controller.ts
@@ -149,44 +149,40 @@ export async function deleteRecipeHandler(
 
 export async function getRecipeCommentsHandler(
   request: FastifyRequest<{
-    Params: { recipeId: string }
+    Params: { id: string }
   }>
 ) {
-  const params = await recipeParamsSchema.parseAsync({
-    id: request.params.recipeId
-  })
+  const { id } = await recipeParamsSchema.parseAsync(request.params)
 
-  const recipe = await getRecipe(params.id)
+  const recipe = await getRecipe(id)
 
   if (!recipe.data) {
     throw new NotFound("No recipe with such ID")
   }
 
-  const comments = await getRecipeComments(params.id)
+  const comments = await getRecipeComments(id)
 
   return comments
 }
 
 export async function createRecipeCommentHandler(
   request: FastifyRequest<{
-    Params: { recipeId: string }
+    Params: { id: string }
     Body: CreateRecipeCommentSchema
   }>,
   reply: FastifyReply
 ) {
-  const params = await recipeParamsSchema.parseAsync({
-    id: request.params.recipeId
-  })
+  const { id } = await recipeParamsSchema.parseAsync(request.params)
   const data = await createRecipeCommentSchema.parseAsync(request.body)
   const { name } = request.user as RequestUser
 
-  const recipe = await getRecipe(params.id)
+  const recipe = await getRecipe(id)
 
   if (!recipe.data) {
     throw new NotFound("No recipe with such ID")
   }
 
-  const comment = await createRecipeComment(params.id, name, data)
+  const comment = await createRecipeComment(id, name, data)
 
   reply.code(201).send(comment)
 }

--- a/apps/v2/src/modules/recipeBook/recipes/recipes.route.ts
+++ b/apps/v2/src/modules/recipeBook/recipes/recipes.route.ts
@@ -96,10 +96,11 @@ async function recipesRoutes(server: FastifyInstance) {
   )
 
   server.get(
-    "/:recipeId/comments",
+    "/:id/comments",
     {
       schema: {
         tags: ["recipe-book-recipes"],
+        params: recipeParamsSchema,
         response: {
           200: createResponseSchema(displayRecipeCommentSchema.array())
         }
@@ -109,12 +110,13 @@ async function recipesRoutes(server: FastifyInstance) {
   )
 
   server.post(
-    "/:recipeId/comments",
+    "/:id/comments",
     {
       onRequest: [server.authenticate, server.apiKey],
       schema: {
         tags: ["recipe-book-recipes"],
         security: [{ bearerAuth: [], apiKey: [] }],
+        params: recipeParamsSchema,
         body: createRecipeCommentSchema,
         response: {
           201: createResponseSchema(displayRecipeCommentSchema)


### PR DESCRIPTION
Fixes the recipe comment route/controller param mismatch that caused 400s and adds dedicated recipes-module tests.

### Changes

- Add `params: recipeParamsSchema` to `/:id/comments` routes and use `{ id: string }` in handlers
- Add `getRecipeComments.test.ts` and `createRecipeComment.test.ts` in the recipes module